### PR TITLE
Enhance builder with sliders and hideable sidebar

### DIFF
--- a/builder_ui.py
+++ b/builder_ui.py
@@ -1,0 +1,198 @@
+import pygame
+
+
+class SliderField:
+    """A simple horizontal slider with an editable numeric field."""
+
+    BOX_WIDTH = 50
+
+    def __init__(self, label, min_val, max_val, get_value, set_value, x, y, width):
+        self.label = label
+        self.min = min_val
+        self.max = max_val
+        self.get_value = get_value
+        self.set_value = set_value
+        self.font = pygame.font.SysFont(None, 22)
+
+        slider_width = width - self.BOX_WIDTH - 10
+        self.slider_rect = pygame.Rect(x, y + 18, slider_width, 6)
+        self.box_rect = pygame.Rect(self.slider_rect.right + 5, y + 10, self.BOX_WIDTH, 22)
+
+        self.dragging = False
+        self.editing = False
+        self.text = ""
+
+    def _value_to_ratio(self, value):
+        return max(0, min(1, (value - self.min) / (self.max - self.min)))
+
+    def _ratio_to_value(self, ratio):
+        return self.min + ratio * (self.max - self.min)
+
+    def draw(self, screen):
+        value = self.get_value()
+        # label
+        lbl = self.font.render(self.label, True, (255, 255, 255))
+        screen.blit(lbl, (self.slider_rect.x, self.slider_rect.y - 18))
+
+        # slider track
+        pygame.draw.rect(screen, (80, 80, 80), self.slider_rect)
+        knob_x = int(self.slider_rect.x + self._value_to_ratio(value) * self.slider_rect.width)
+        pygame.draw.rect(screen, (180, 180, 180), (knob_x - 3, self.slider_rect.y - 4, 6, self.slider_rect.height + 8))
+
+        # textbox
+        pygame.draw.rect(screen, (255, 255, 255), self.box_rect, 1)
+        txt = self.text if self.editing else f"{value:.2f}"
+        img = self.font.render(txt, True, (255, 255, 255))
+        rect = img.get_rect(center=self.box_rect.center)
+        screen.blit(img, rect)
+
+    def handle_event(self, event):
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.slider_rect.collidepoint(event.pos):
+                self.dragging = True
+                self._update_value(event.pos[0])
+                return True
+            if self.box_rect.collidepoint(event.pos):
+                self.editing = True
+                self.text = ""
+                return True
+        elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
+            self.dragging = False
+        elif event.type == pygame.MOUSEMOTION and self.dragging:
+            self._update_value(event.pos[0])
+            return True
+        elif event.type == pygame.KEYDOWN and self.editing:
+            if event.key == pygame.K_RETURN:
+                try:
+                    val = float(self.text)
+                    val = max(self.min, min(self.max, val))
+                    self.set_value(val)
+                except ValueError:
+                    pass
+                self.editing = False
+                return True
+            elif event.key == pygame.K_BACKSPACE:
+                self.text = self.text[:-1]
+                return True
+            else:
+                ch = event.unicode
+                if ch.isdigit() or ch in "-.":
+                    self.text += ch
+                    return True
+        return False
+
+    def _update_value(self, mouse_x):
+        ratio = (mouse_x - self.slider_rect.x) / self.slider_rect.width
+        ratio = max(0, min(1, ratio))
+        self.set_value(self._ratio_to_value(ratio))
+
+
+class SidebarUI:
+    BUTTON_HEIGHT = 28
+    BUTTON_MARGIN = 4
+    WIDTH = 220
+    TOGGLE_SIZE = 20
+
+    def __init__(self, screen: pygame.Surface, app):
+        self.screen = screen
+        self.app = app
+        self.font = pygame.font.SysFont(None, 24)
+        self.buttons = []
+        self.fields = []
+        self.visible = True
+        self._setup_ui()
+
+    # ----------------------------------------------------------- setup
+    def _setup_ui(self):
+        sw = self.screen.get_width()
+        x = sw - self.WIDTH + 10
+        y = 10
+
+        def add_button(label, action):
+            nonlocal y
+            rect = pygame.Rect(x, y, self.WIDTH - 20, self.BUTTON_HEIGHT)
+            self.buttons.append({"rect": rect, "label": label, "action": action})
+            y += self.BUTTON_HEIGHT + self.BUTTON_MARGIN
+
+        add_button("Drag", lambda: self.app.set_mode("drag"))
+        add_button("Particle", lambda: self.app.set_mode("particle"))
+        add_button("Spring", lambda: self.app.set_mode("spring"))
+        add_button("Delete", lambda: self.app.set_mode("delete"))
+        add_button("Cycle Color", self.app.cycle_color)
+        add_button(lambda: "Resume" if self.app.paused else "Pause", self.app.toggle_pause)
+
+        # sliders
+        slider_x = sw - self.WIDTH + 10
+        slider_width = self.WIDTH - 20
+        y += 10
+        self.fields.append(
+            SliderField("Mass", 0.1, 10.0, lambda: self.app.mass, self.app.set_mass, slider_x, y, slider_width)
+        )
+        y += 40
+        self.fields.append(
+            SliderField("Radius", 1, 50, lambda: self.app.radius, self.app.set_radius, slider_x, y, slider_width)
+        )
+        y += 40
+        self.fields.append(
+            SliderField(
+                "Stiff", 10, 1000, lambda: self.app.stiffness, self.app.set_stiffness, slider_x, y, slider_width
+            )
+        )
+        y += 40
+        self.fields.append(
+            SliderField(
+                "Temp", 0, 1000, lambda: self.app.physics.temperature, self.app.set_temperature, slider_x, y, slider_width
+            )
+        )
+
+    def visible_width(self):
+        return self.WIDTH if self.visible else 0
+
+    # ----------------------------------------------------------- draw
+    def draw(self):
+        sw = self.screen.get_width()
+        sidebar_rect = pygame.Rect(sw - self.visible_width(), 0, self.visible_width(), self.screen.get_height())
+        toggle_x = sw - self.visible_width() - self.TOGGLE_SIZE
+        self.toggle_rect = pygame.Rect(toggle_x, 5, self.TOGGLE_SIZE, self.TOGGLE_SIZE)
+
+        # background
+        if self.visible:
+            pygame.draw.rect(self.screen, (50, 50, 50), sidebar_rect)
+
+            for btn in self.buttons:
+                label = btn["label"]() if callable(btn["label"]) else btn["label"]
+                pygame.draw.rect(self.screen, (80, 80, 80), btn["rect"])
+                text_img = self.font.render(label, True, (255, 255, 255))
+                text_rect = text_img.get_rect(center=btn["rect"].center)
+                self.screen.blit(text_img, text_rect)
+
+            for field in self.fields:
+                field.draw(self.screen)
+
+        # toggle button (always visible)
+        pygame.draw.rect(self.screen, (100, 100, 100), self.toggle_rect)
+        arrow = "<" if self.visible else ">"
+        img = self.font.render(arrow, True, (255, 255, 255))
+        rect = img.get_rect(center=self.toggle_rect.center)
+        self.screen.blit(img, rect)
+
+    # ----------------------------------------------------------- event handler
+    def handle_event(self, event):
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.toggle_rect.collidepoint(event.pos):
+                self.visible = not self.visible
+                return True
+
+        if self.visible:
+            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                for btn in self.buttons:
+                    if btn["rect"].collidepoint(event.pos):
+                        btn["action"]()
+                        return True
+
+        if self.visible:
+            for field in self.fields:
+                if field.handle_event(event):
+                    return True
+
+        return False

--- a/start_create.py
+++ b/start_create.py
@@ -1,0 +1,236 @@
+import pygame
+
+from particle import Particle
+from spring import Spring
+from physics import PhysicsEngine
+from renderer import Renderer
+from builder_ui import SidebarUI
+
+SCREEN_SIZE = (1300, 900)
+FPS = 120
+
+
+class BuilderApp:
+    def __init__(self):
+        pygame.init()
+        self.screen = pygame.display.set_mode(SCREEN_SIZE)
+        pygame.display.set_caption("Particle Builder")
+        self.clock = pygame.time.Clock()
+        self.particles: list[Particle] = []
+        self.springs: list[Spring] = []
+        self.selected = None
+        self.spring_first = None
+        self.paused = False
+
+        # parameters for creation
+        self.mode = "drag"  # drag, particle, spring
+        self.mass = 1.0
+        self.radius = 10
+        self.color_cycle = [
+            (255, 0, 0),
+            (0, 255, 0),
+            (0, 0, 255),
+            (255, 255, 255),
+            (255, 255, 0),
+            (0, 255, 255),
+        ]
+        self.color_index = 0
+        self.color = self.color_cycle[self.color_index]
+        self.stiffness = 200.0
+
+        self.font = pygame.font.SysFont(None, 24)
+        self.physics = PhysicsEngine(
+            self.particles,
+            self.springs,
+            gravity=(0, 0),
+            repulsion_radius=30,
+            repulsion_strength=1000,
+            temperature=0,
+            damping_coeff=1,
+        )
+        self.renderer = Renderer(self.screen)
+        self.ui = SidebarUI(self.screen, self)
+
+    # ------------------------------------------------------------------ parameter helpers
+    def set_mode(self, mode: str):
+        self.mode = mode
+        if mode != "spring":
+            self.spring_first = None
+        if self.selected and mode != "drag":
+            self.selected.fixed = False
+            self.selected = None
+
+    def cycle_color(self):
+        self.color_index = (self.color_index + 1) % len(self.color_cycle)
+        self.color = self.color_cycle[self.color_index]
+
+    def adjust_mass(self, delta: float):
+        self.mass = max(0.1, self.mass + delta)
+
+    def set_mass(self, value: float):
+        self.mass = max(0.1, value)
+
+    def adjust_radius(self, delta: int):
+        self.radius = max(1, self.radius + delta)
+
+    def set_radius(self, value: float):
+        self.radius = max(1, int(value))
+
+    def adjust_stiffness(self, delta: float):
+        self.stiffness = max(10, self.stiffness + delta)
+
+    def set_stiffness(self, value: float):
+        self.stiffness = max(10, value)
+
+    def adjust_temperature(self, delta: float):
+        self.physics.temperature = max(0, self.physics.temperature + delta)
+
+    def set_temperature(self, value: float):
+        self.physics.temperature = max(0, value)
+
+    def toggle_pause(self):
+        self.paused = not self.paused
+
+    # ------------------------------------------------------------------ main
+    def run(self):
+        running = True
+        while running:
+            dt = self.clock.tick(FPS) / 1000
+
+            for e in pygame.event.get():
+                if self.ui.handle_event(e):
+                    continue
+
+                if e.type == pygame.QUIT:
+                    running = False
+
+                elif e.type == pygame.KEYDOWN:
+                    if e.key == pygame.K_1:
+                        self.set_mode("drag")
+                    elif e.key == pygame.K_2:
+                        self.set_mode("particle")
+                    elif e.key == pygame.K_3:
+                        self.set_mode("spring")
+                    elif e.key == pygame.K_4:
+                        self.set_mode("delete")
+                    elif e.key == pygame.K_c:
+                        self.cycle_color()
+                    elif e.key == pygame.K_z:
+                        self.adjust_mass(-0.1)
+                    elif e.key == pygame.K_x:
+                        self.adjust_mass(0.1)
+                    elif e.key == pygame.K_v:
+                        self.adjust_radius(-1)
+                    elif e.key == pygame.K_b:
+                        self.adjust_radius(1)
+                    elif e.key == pygame.K_k:
+                        self.adjust_stiffness(-10)
+                    elif e.key == pygame.K_l:
+                        self.adjust_stiffness(10)
+                    elif e.key == pygame.K_n:
+                        self.adjust_temperature(-10)
+                    elif e.key == pygame.K_m:
+                        self.adjust_temperature(10)
+                    elif e.key == pygame.K_p:
+                        self.toggle_pause()
+                    elif e.key == pygame.K_ESCAPE:
+                        self.spring_first = None
+
+                elif e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
+                    mouse = pygame.Vector2(e.pos)
+                    if self.mode == "drag":
+                        if self.particles:
+                            self.selected = min(
+                                self.particles, key=lambda p: (p.pos - mouse).length()
+                            )
+                            self.selected.fixed = True
+                    elif self.mode == "particle":
+                        p = Particle(mouse, mass=self.mass, color=self.color, radius=self.radius)
+                        self.particles.append(p)
+                    elif self.mode == "spring":
+                        if self.particles:
+                            particle = min(
+                                self.particles, key=lambda p: (p.pos - mouse).length()
+                            )
+                            if self.spring_first is None:
+                                self.spring_first = particle
+                            else:
+                                rest = (particle.pos - self.spring_first.pos).length()
+                                s = Spring(
+                                    self.spring_first,
+                                    particle,
+                                    rest_length=rest,
+                                    stiffness=self.stiffness,
+                                )
+                                self.springs.append(s)
+                                self.spring_first = None
+                    elif self.mode == "delete":
+                        # remove closest particle or spring
+                        target_p = None
+                        target_s = None
+                        dist_p = float("inf")
+                        dist_s = float("inf")
+                        if self.particles:
+                            target_p = min(self.particles, key=lambda p: (p.pos - mouse).length())
+                            dist_p = (target_p.pos - mouse).length()
+                        if self.springs:
+                            def mid_dist(s):
+                                mid = (s.p1.pos + s.p2.pos) * 0.5
+                                return (mid - mouse).length()
+                            target_s = min(self.springs, key=mid_dist)
+                            dist_s = mid_dist(target_s)
+                        if dist_p < dist_s and dist_p < 30 and target_p:
+                            self.particles.remove(target_p)
+                            self.springs = [s for s in self.springs if s.p1 != target_p and s.p2 != target_p]
+                        elif dist_s < 30 and target_s:
+                            self.springs.remove(target_s)
+
+                elif e.type == pygame.MOUSEBUTTONUP and e.button == 1:
+                    if self.selected:
+                        self.selected.fixed = False
+                        self.selected = None
+
+            if self.selected:
+                self.selected.pos = pygame.Vector2(pygame.mouse.get_pos())
+                self.selected.prev_pos = self.selected.pos.copy()
+
+            if not self.paused:
+                self.physics.update(dt)
+
+            # keep particles inside the window and out of the sidebar
+            max_x = self.screen.get_width() - self.ui.visible_width()
+            max_y = self.screen.get_height()
+            for p in self.particles:
+                if p.pos.x < 0:
+                    p.pos.x = 0
+                    p.prev_pos.x = p.pos.x
+                elif p.pos.x > max_x:
+                    p.pos.x = max_x
+                    p.prev_pos.x = p.pos.x
+                if p.pos.y < 0:
+                    p.pos.y = 0
+                    p.prev_pos.y = p.pos.y
+                elif p.pos.y > max_y:
+                    p.pos.y = max_y
+                    p.prev_pos.y = p.pos.y
+
+            self.screen.fill((30, 30, 30))
+            self.renderer.draw(self.particles, self.springs)
+            self.ui.draw()
+            # highlight first spring particle
+            if self.spring_first is not None and self.mode == "spring":
+                pygame.draw.circle(
+                    self.screen,
+                    (255, 255, 0),
+                    (int(self.spring_first.pos.x), int(self.spring_first.pos.y)),
+                    self.spring_first.radius + 4,
+                    2,
+                )
+            pygame.display.flip()
+
+        pygame.quit()
+
+
+if __name__ == "__main__":
+    app = BuilderApp()
+    app.run()


### PR DESCRIPTION
## Summary
- replace mass/radius/stiffness/temperature buttons with sliders and numeric boxes
- add toggleable sidebar
- prevent particles from crossing window borders or hiding behind the UI

## Testing
- `python -m py_compile start_create.py builder_ui.py`


------
https://chatgpt.com/codex/tasks/task_e_6883851525f0832587e303595b247e45