### PR TITLE
Add rod creation tool with preview

### DIFF
--- a/builder_ui.py
+++ b/builder_ui.py
@@ -188,6 +188,185 @@ class CircleTool:
         return False
 
 
+class RodTool:
+    """Handle rod preview creation with sliders and click placement."""
+
+    def __init__(self, sidebar: 'SidebarUI'):
+        self.sidebar = sidebar
+        self.app = sidebar.app
+        self.active = False
+        self.center = None
+        self.radius = 30.0
+        self.length = 100.0
+        self.segments = 20
+        self.skeleton_count = 5
+        self.include_cytoskeleton = False
+        self.include_skeleton = False
+        self.dragging = False
+
+        x = sidebar.screen.get_width() - sidebar.WIDTH + 10
+        width = sidebar.WIDTH - 20
+        y = sidebar.extra_start_y
+
+        self.radius_field = SliderField(
+            "R Radius", 5, 200, lambda: self.radius, self._set_radius, x, y, width
+        )
+        y += 40
+        self.length_field = SliderField(
+            "Length", 10, 600, lambda: self.length, self._set_length, x, y, width
+        )
+        y += 40
+        self.segments_field = SliderField(
+            "Segments", 4, 200, lambda: self.segments, self._set_segments, x, y, width
+        )
+        y += 40
+        self.skel_count_field = SliderField(
+            "Skeleton", 1, 20, lambda: self.skeleton_count, self._set_skel_count, x, y, width
+        )
+        y += 40
+        self.cyto_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
+        y += SidebarUI.BUTTON_HEIGHT + 4
+        self.skeleton_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
+        y += SidebarUI.BUTTON_HEIGHT + 4
+        self.create_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
+
+    # ---------------- value setters
+    def _set_radius(self, value: float):
+        self.radius = max(1, value)
+
+    def _set_length(self, value: float):
+        self.length = max(1, value)
+
+    def _set_segments(self, value: float):
+        self.segments = max(4, int(value))
+
+    def _set_skel_count(self, value: float):
+        self.skeleton_count = max(1, int(value))
+
+    # ---------------- control
+    def start(self):
+        self.active = True
+        self.center = None
+
+    def cancel(self):
+        self.active = False
+        self.dragging = False
+
+    # ---------------- helpers
+    def _generate_points(self):
+        center = self.center
+        if center is None:
+            return []
+        radius = self.radius
+        length = self.length
+        segments = self.segments
+        pts = []
+        total_length = 2 * length + 2 * math.pi * radius
+        step = total_length / segments
+        center_left = center + pygame.Vector2(-length / 2, 0)
+        center_right = center + pygame.Vector2(length / 2, 0)
+        for i in range(segments):
+            s = i * step
+            if s < math.pi * radius:
+                theta = math.pi / 2 + (s / (math.pi * radius)) * math.pi
+                pos = center_left + pygame.Vector2(math.cos(theta), math.sin(theta)) * radius
+            elif s < math.pi * radius + length:
+                pos = pygame.Vector2(center_left.x + (s - math.pi * radius), center.y - radius)
+            elif s < 2 * math.pi * radius + length:
+                theta = 3 * math.pi / 2 + ((s - math.pi * radius - length) / (math.pi * radius)) * math.pi
+                pos = center_right + pygame.Vector2(math.cos(theta), math.sin(theta)) * radius
+            else:
+                pos = pygame.Vector2(
+                    center_right.x - (s - 2 * math.pi * radius - length), center.y + radius
+                )
+            pts.append(pos)
+        return pts
+
+    # ---------------- drawing
+    def draw_ui(self):
+        if not self.active or not self.sidebar.visible:
+            return
+        self.radius_field.draw(self.sidebar.screen)
+        self.length_field.draw(self.sidebar.screen)
+        self.segments_field.draw(self.sidebar.screen)
+        self.skel_count_field.draw(self.sidebar.screen)
+        pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.cyto_rect)
+        cyto_txt = "Cyto: On" if self.include_cytoskeleton else "Cyto: Off"
+        txt = self.sidebar.font.render(cyto_txt, True, (255, 255, 255))
+        rect = txt.get_rect(center=self.cyto_rect.center)
+        self.sidebar.screen.blit(txt, rect)
+        pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.skeleton_rect)
+        skel_txt = "Skel: On" if self.include_skeleton else "Skel: Off"
+        txt = self.sidebar.font.render(skel_txt, True, (255, 255, 255))
+        rect = txt.get_rect(center=self.skeleton_rect.center)
+        self.sidebar.screen.blit(txt, rect)
+        pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.create_rect)
+        txt = self.sidebar.font.render("Create", True, (255, 255, 255))
+        rect = txt.get_rect(center=self.create_rect.center)
+        self.sidebar.screen.blit(txt, rect)
+
+    def draw_preview(self):
+        if not self.active or self.center is None:
+            return
+        screen = self.sidebar.screen
+        color = (150, 150, 150)
+        pts = self._generate_points()
+        for i in range(len(pts)):
+            p1 = pts[i]
+            p2 = pts[(i + 1) % len(pts)]
+            pygame.draw.line(screen, color, p1, p2, 1)
+            pygame.draw.circle(screen, color, (int(p1.x), int(p1.y)), self.app.radius, 1)
+
+    # ---------------- event handling
+    def handle_event(self, event):
+        if not self.active:
+            return False
+
+        if self.sidebar.visible:
+            if self.radius_field.handle_event(event):
+                return True
+            if self.length_field.handle_event(event):
+                return True
+            if self.segments_field.handle_event(event):
+                return True
+            if self.skel_count_field.handle_event(event):
+                return True
+            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                if self.cyto_rect.collidepoint(event.pos):
+                    self.include_cytoskeleton = not self.include_cytoskeleton
+                    return True
+                if self.skeleton_rect.collidepoint(event.pos):
+                    self.include_skeleton = not self.include_skeleton
+                    return True
+                if self.create_rect.collidepoint(event.pos) and self.center:
+                    self.app.create_rod(
+                        self.center,
+                        self.radius,
+                        self.length,
+                        self.segments,
+                        self.include_cytoskeleton,
+                        self.include_skeleton,
+                        self.skeleton_count,
+                    )
+                    self.cancel()
+                    self.sidebar.app.set_mode("drag")
+                    return True
+
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if event.pos[0] < self.sidebar.screen.get_width() - self.sidebar.visible_width():
+                self.center = pygame.Vector2(event.pos)
+                self.dragging = True
+                return True
+        elif event.type == pygame.MOUSEMOTION and self.dragging:
+            self.length = abs(event.pos[0] - self.center.x) * 2
+            return True
+        elif event.type == pygame.MOUSEBUTTONUP and event.button == 1 and self.dragging:
+            self.dragging = False
+            return True
+
+        return False
+
+
 class SidebarUI:
     BUTTON_HEIGHT = 28
     BUTTON_MARGIN = 4
@@ -205,6 +384,7 @@ class SidebarUI:
         self._setup_ui()
         # setup circle tool after computing layout
         self.circle_tool = CircleTool(self)
+        self.rod_tool = RodTool(self)
 
     # ----------------------------------------------------------- setup
     def _setup_ui(self):
@@ -222,6 +402,7 @@ class SidebarUI:
         add_button("Particle", lambda: self.app.set_mode("particle"))
         add_button("Spring", lambda: self.app.set_mode("spring"))
         add_button("Circle", lambda: self.app.set_mode("circle"))
+        add_button("Rod", lambda: self.app.set_mode("rod"))
         add_button("Delete", lambda: self.app.set_mode("delete"))
         add_button("Cycle Color", self.app.cycle_color)
         add_button(lambda: "Resume" if self.app.paused else "Pause", self.app.toggle_pause)
@@ -278,9 +459,11 @@ class SidebarUI:
 
             # extra UI from tools
             self.circle_tool.draw_ui()
+            self.rod_tool.draw_ui()
 
         # preview from tools (visible or not)
         self.circle_tool.draw_preview()
+        self.rod_tool.draw_preview()
 
         # toggle button (always visible)
         pygame.draw.rect(self.screen, (100, 100, 100), self.toggle_rect)
@@ -309,6 +492,8 @@ class SidebarUI:
                     return True
 
         if self.circle_tool.handle_event(event):
+            return True
+        if self.rod_tool.handle_event(event):
             return True
 
         return False

--- a/start_create.py
+++ b/start_create.py
@@ -6,6 +6,7 @@ from spring import Spring
 from physics import PhysicsEngine
 from renderer import Renderer
 from builder_ui import SidebarUI
+from structures import create_rod as structure_create_rod
 
 SCREEN_SIZE = (1300, 900)
 FPS = 120
@@ -24,7 +25,7 @@ class BuilderApp:
         self.paused = False
 
         # parameters for creation
-        self.mode = "drag"  # drag, particle, spring
+        self.mode = "drag"  # drag, particle, spring, rod
         self.mass = 1.0
         self.radius = 10
         self.color_cycle = [
@@ -56,10 +57,14 @@ class BuilderApp:
     def set_mode(self, mode: str):
         if self.mode == "circle" and mode != "circle":
             self.ui.circle_tool.cancel()
+        if self.mode == "rod" and mode != "rod":
+            self.ui.rod_tool.cancel()
 
         self.mode = mode
         if mode == "circle":
             self.ui.circle_tool.start()
+        if mode == "rod":
+            self.ui.rod_tool.start()
         if mode != "spring":
             self.spring_first = None
         if self.selected and mode != "drag":
@@ -114,6 +119,37 @@ class BuilderApp:
         self.particles.extend(particles)
         self.springs.extend(springs)
 
+    def create_rod(
+        self,
+        center: pygame.Vector2,
+        radius: float,
+        length: float,
+        segments: int,
+        include_cytoskeleton: bool,
+        include_skeleton: bool,
+        skeleton_count: int,
+    ):
+        particles, springs = structure_create_rod(
+            center,
+            radius=radius,
+            length=length,
+            segments=segments,
+            stiffness=self.stiffness,
+            max_force=None,
+            color=self.color,
+            include_cytoskeleton=include_cytoskeleton,
+            cyto_stiffness=self.stiffness,
+            include_skeleton=include_skeleton,
+            skeleton_count=skeleton_count,
+            skeleton_stiffness=self.stiffness,
+        )
+        for p in particles:
+            p.mass = self.mass
+            p.radius = self.radius
+            p.color = self.color
+        self.particles.extend(particles)
+        self.springs.extend(springs)
+
     # ------------------------------------------------------------------ main
     def run(self):
         running = True
@@ -136,6 +172,8 @@ class BuilderApp:
                         self.set_mode("spring")
                     elif e.key == pygame.K_4:
                         self.set_mode("delete")
+                    elif e.key == pygame.K_5:
+                        self.set_mode("rod")
                     elif e.key == pygame.K_c:
                         self.cycle_color()
                     elif e.key == pygame.K_z:
@@ -207,6 +245,8 @@ class BuilderApp:
                             self.springs = [s for s in self.springs if s.p1 != target_p and s.p2 != target_p]
                         elif dist_s < 30 and target_s:
                             self.springs.remove(target_s)
+                    elif self.mode == "rod":
+                        pass  # handled by rod tool
 
                 elif e.type == pygame.MOUSEBUTTONUP and e.button == 1:
                     if self.selected:


### PR DESCRIPTION
## Summary
- extend the sidebar UI with a new `RodTool`
- allow creating rods from the builder
- support adjustable length, radius, segments and skeleton options
- handle rod mode in `start_create.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6888e912633c8325b770554fd8cacfaf