### PR TITLE
Add color picker UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ### Simulation of 2D cells
 (or at least I hope so)
 
-all particles can be grabbed with left mouse click
+This project provides a basic 2D cell builder using Pygame. Run
+`start_create.py` to experiment with particles, springs and rods. All
+particles can be grabbed with the left mouse button.
 
 - o = add a single loose particle
 - p = add 10 loose particles
@@ -18,6 +20,8 @@ all particles can be grabbed with left mouse click
 - q = freeze loose particles 
 - w = unfreeze loose particles
 
-These are slight changes to check if github works
+Press **c** or use the **Color** field in the sidebar to open a color
+picker. The picker allows choosing any color or entering a hex value
+like `#FF00FF`.
 
 ![Repo Size](https://img.shields.io/github/repo-size/USERNAME/REPOSITORY)

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -1,5 +1,6 @@
 import pygame
 import math
+from tkinter import Tk, colorchooser
 
 
 class SliderField:
@@ -86,6 +87,90 @@ class SliderField:
         ratio = (mouse_x - self.slider_rect.x) / self.slider_rect.width
         ratio = max(0, min(1, ratio))
         self.set_value(self._ratio_to_value(ratio))
+
+
+class ColorField:
+    """Field allowing the user to pick a color or enter a hex value."""
+
+    BOX_WIDTH = 70
+    COLOR_SIZE = 24
+
+    def __init__(self, label, get_color, set_color, x, y, width):
+        self.label = label
+        self.get_color = get_color
+        self.set_color = set_color
+        self.font = pygame.font.SysFont(None, 22)
+
+        self.color_rect = pygame.Rect(x, y + 14, self.COLOR_SIZE, self.COLOR_SIZE)
+        self.box_rect = pygame.Rect(
+            self.color_rect.right + 5, y + 10, self.BOX_WIDTH, 22
+        )
+
+        self.editing = False
+        self.text = ""
+
+    def draw(self, screen):
+        color = self.get_color()
+        lbl = self.font.render(self.label, True, (255, 255, 255))
+        screen.blit(lbl, (self.color_rect.x, self.color_rect.y - 18))
+
+        pygame.draw.rect(screen, color, self.color_rect)
+        pygame.draw.rect(screen, (255, 255, 255), self.color_rect, 1)
+
+        pygame.draw.rect(screen, (255, 255, 255), self.box_rect, 1)
+        txt = self.text if self.editing else "#%02X%02X%02X" % color
+        img = self.font.render(txt, True, (255, 255, 255))
+        rect = img.get_rect(center=self.box_rect.center)
+        screen.blit(img, rect)
+
+    def handle_event(self, event):
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.color_rect.collidepoint(event.pos):
+                self._choose_color()
+                return True
+            if self.box_rect.collidepoint(event.pos):
+                self.editing = True
+                self.text = ""
+                return True
+        elif event.type == pygame.KEYDOWN and self.editing:
+            if event.key == pygame.K_RETURN:
+                self._set_color_hex(self.text)
+                self.editing = False
+                return True
+            elif event.key == pygame.K_BACKSPACE:
+                self.text = self.text[:-1]
+                return True
+            else:
+                ch = event.unicode.upper()
+                if ch in "0123456789ABCDEF#":
+                    self.text += ch
+                    return True
+        return False
+
+    def _choose_color(self):
+        try:
+            root = Tk()
+            root.withdraw()
+            initial = "#%02x%02x%02x" % self.get_color()
+            rgb, _ = colorchooser.askcolor(color=initial, parent=root)
+            root.destroy()
+            if rgb:
+                r, g, b = map(int, rgb)
+                self.set_color((r, g, b))
+        except Exception:
+            pass
+
+    def _set_color_hex(self, value: str):
+        value = value.lstrip("#")
+        if len(value) != 6:
+            return
+        try:
+            r = int(value[0:2], 16)
+            g = int(value[2:4], 16)
+            b = int(value[4:6], 16)
+            self.set_color((r, g, b))
+        except ValueError:
+            pass
 
 
 class CircleTool:
@@ -462,13 +547,17 @@ class SidebarUI:
         add_button("Circle", lambda: self.app.set_mode("circle"))
         add_button("Rod", lambda: self.app.set_mode("rod"))
         add_button("Delete", lambda: self.app.set_mode("delete"))
-        add_button("Cycle Color", self.app.cycle_color)
         add_button(lambda: "Resume" if self.app.paused else "Pause", self.app.toggle_pause)
 
         # sliders
         slider_x = sw - self.WIDTH + 10
         slider_width = self.WIDTH - 20
         y += 10
+        color_field = ColorField(
+            "Color", lambda: self.app.color, self.app.set_color, slider_x, y, slider_width
+        )
+        self.fields.append(color_field)
+        y += 40
         self.fields.append(
             SliderField("Mass", 0.1, 10.0, lambda: self.app.mass, self.app.set_mass, slider_x, y, slider_width)
         )

--- a/start_create.py
+++ b/start_create.py
@@ -13,6 +13,7 @@ FPS = 120
 
 
 class BuilderApp:
+    """Main application class for the particle builder demo."""
     def __init__(self):
         pygame.init()
         self.screen = pygame.display.set_mode(SCREEN_SIZE)
@@ -28,16 +29,7 @@ class BuilderApp:
         self.mode = "drag"  # drag, particle, spring, rod
         self.mass = 1.0
         self.radius = 10
-        self.color_cycle = [
-            (255, 0, 0),
-            (0, 255, 0),
-            (0, 0, 255),
-            (255, 255, 255),
-            (255, 255, 0),
-            (0, 255, 255),
-        ]
-        self.color_index = 0
-        self.color = self.color_cycle[self.color_index]
+        self.color = (255, 0, 0)
         self.stiffness = 200.0
 
         self.font = pygame.font.SysFont(None, 24)
@@ -71,9 +63,38 @@ class BuilderApp:
             self.selected.fixed = False
             self.selected = None
 
-    def cycle_color(self):
-        self.color_index = (self.color_index + 1) % len(self.color_cycle)
-        self.color = self.color_cycle[self.color_index]
+    def choose_color(self):
+        """Open a color chooser dialog and update the current color."""
+        try:
+            from tkinter import Tk, colorchooser
+            root = Tk()
+            root.withdraw()
+            rgb, _ = colorchooser.askcolor(color=self.get_color_hex(), parent=root)
+            root.destroy()
+            if rgb:
+                r, g, b = map(int, rgb)
+                self.color = (r, g, b)
+        except Exception:
+            pass
+
+    def set_color(self, color):
+        self.color = color
+
+    def get_color_hex(self) -> str:
+        r, g, b = self.color
+        return f"#{r:02X}{g:02X}{b:02X}"
+
+    def set_color_hex(self, value: str):
+        value = value.lstrip("#")
+        if len(value) != 6:
+            return
+        try:
+            r = int(value[0:2], 16)
+            g = int(value[2:4], 16)
+            b = int(value[4:6], 16)
+            self.color = (r, g, b)
+        except ValueError:
+            pass
 
     def adjust_mass(self, delta: float):
         self.mass = max(0.1, self.mass + delta)
@@ -175,7 +196,7 @@ class BuilderApp:
                     elif e.key == pygame.K_5:
                         self.set_mode("rod")
                     elif e.key == pygame.K_c:
-                        self.cycle_color()
+                        self.choose_color()
                     elif e.key == pygame.K_z:
                         self.adjust_mass(-0.1)
                     elif e.key == pygame.K_x:


### PR DESCRIPTION
## Summary
- add a `ColorField` UI element that uses a color wheel popup
- allow editing color using hex
- replace the old cycle-color behaviour in `start_create.py`
- document the new feature in README
- add docstrings for clarity

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6888f0c6c6ac83258eb3b958ea805cfe