### PR TITLE
Fix color chooser crash on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ particles can be grabbed with the left mouse button.
 - w = unfreeze loose particles
 
 Press **c** or use the **Color** field in the sidebar to open a color
-picker. The picker allows choosing any color or entering a hex value
-like `#FF00FF`.
+picker. The picker is launched in a small helper process so it works on
+all platforms. You can choose any color or enter a hex value like
+`#FF00FF`.
 
 ![Repo Size](https://img.shields.io/github/repo-size/USERNAME/REPOSITORY)

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -1,6 +1,6 @@
 import pygame
 import math
-from tkinter import Tk, colorchooser
+from color_picker import choose_color
 
 
 class SliderField:
@@ -148,17 +148,10 @@ class ColorField:
         return False
 
     def _choose_color(self):
-        try:
-            root = Tk()
-            root.withdraw()
-            initial = "#%02x%02x%02x" % self.get_color()
-            rgb, _ = colorchooser.askcolor(color=initial, parent=root)
-            root.destroy()
-            if rgb:
-                r, g, b = map(int, rgb)
-                self.set_color((r, g, b))
-        except Exception:
-            pass
+        """Launch the color picker in a separate process."""
+        rgb = choose_color(self.get_color())
+        if rgb:
+            self.set_color(rgb)
 
     def _set_color_hex(self, value: str):
         value = value.lstrip("#")

--- a/color_picker.py
+++ b/color_picker.py
@@ -1,0 +1,30 @@
+"""Utility to pick a color using Tkinter in a separate process."""
+from multiprocessing import Pipe, Process
+from typing import Optional, Tuple
+
+
+def _chooser_process(initial: str, conn) -> None:
+    """Open Tkinter color chooser and send the selected RGB value."""
+    try:
+        from tkinter import Tk, colorchooser
+        root = Tk()
+        root.withdraw()
+        rgb, _ = colorchooser.askcolor(color=initial)
+        root.destroy()
+    except Exception:  # pragma: no cover - Tkinter might not be available
+        rgb = None
+    conn.send(rgb)
+    conn.close()
+
+
+def choose_color(initial: Tuple[int, int, int]) -> Optional[Tuple[int, int, int]]:
+    """Return an RGB tuple selected by the user or ``None`` if canceled."""
+    hex_color = "#%02x%02x%02x" % initial
+    parent_conn, child_conn = Pipe()
+    process = Process(target=_chooser_process, args=(hex_color, child_conn))
+    process.start()
+    rgb = parent_conn.recv()
+    process.join()
+    if rgb:
+        return tuple(map(int, rgb))
+    return None

--- a/start_create.py
+++ b/start_create.py
@@ -64,18 +64,12 @@ class BuilderApp:
             self.selected = None
 
     def choose_color(self):
-        """Open a color chooser dialog and update the current color."""
-        try:
-            from tkinter import Tk, colorchooser
-            root = Tk()
-            root.withdraw()
-            rgb, _ = colorchooser.askcolor(color=self.get_color_hex(), parent=root)
-            root.destroy()
-            if rgb:
-                r, g, b = map(int, rgb)
-                self.color = (r, g, b)
-        except Exception:
-            pass
+        """Open the color chooser in a separate process and update the color."""
+        from color_picker import choose_color
+
+        rgb = choose_color(self.color)
+        if rgb:
+            self.color = rgb
 
     def set_color(self, color):
         self.color = color


### PR DESCRIPTION
## Summary
- introduce a dedicated `color_picker` module
- use the helper in `builder_ui` and `start_create` to open the picker in a subprocess
- document the new behaviour in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888f2d101cc8325b87f2444dbafdd6d