### PR TITLE
Document demo controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,25 @@ Particles can be grabbed with the left mouse button.  When in spring mode, click
 
 ## Example demos
 
-Other start files demonstrate specific setups:
+Other start files demonstrate specific setups and each window supports simple
+keyboard shortcuts:
 
-* `start.py` – concentric circular walls representing a simple cell.
-* `start_basic.py` – minimal ring of particles.
-* `start_rod.py` – a capsule‑shaped structure.
-* `start_bending_wall.py` – uses bending springs to keep angles between segments.
-* `start_four_rods.py`, `start_gradient_wall.py` – various experiments with rods and walls.
+* **`start.py`** – three nested circular walls that behave like a soft cell.
+  Press **O**/**P** to spawn loose particles, **K/L** to tweak spring
+  stiffness, **N/M** to change the temperature and **Q/W** to freeze or unfreeze
+  loose particles.
+* **`start_basic.py`** – a minimal ring of particles.  Only dragging with the
+  left mouse button is implemented.
+* **`start_rod.py`** – shows a capsule‑shaped rod; controls are the same as in
+  `start.py`.
+* **`start_bending_wall.py`** – demonstrates bending springs.  Keys **D**, **F**
+  and **G** temporarily shorten individual springs while **B**, **N** and **M**
+  toggle high drag on selected particles.  All other controls from `start.py`
+  are also available.
+* **`start_four_rods.py`** – four rods positioned around the centre with the
+  same controls as `start.py`.
+* **`start_gradient_wall.py`** – similar to `start_four_rods.py` but colours each
+  rod with a gradient.
 
 Feel free to modify any of these scripts or build new configurations using the interactive builder.
 

--- a/start.py
+++ b/start.py
@@ -1,4 +1,10 @@
-# main.py
+"""Demo with three concentric walls behaving like a soft cell.
+
+Loose particles can be spawned with **O**/**P**, spring stiffness adjusted with
+**K/L** and the temperature changed with **N/M**. Press **Q/W** to freeze or
+unfreeze loose particles.
+"""
+
 import math
 import random
 
@@ -19,6 +25,8 @@ FPS = 120
 
 
 class CellWallApp:
+    """Left click to drag particles, use keys to spawn and modify the scene."""
+
     def __init__(self):
         pygame.init()
         self.screen = pygame.display.set_mode(SCREEN_SIZE)

--- a/start_basic.py
+++ b/start_basic.py
@@ -1,4 +1,8 @@
-# main.py
+"""Minimal demo showing a single ring of particles connected by springs.
+
+The scene only supports dragging particles with the left mouse button.
+"""
+
 import pygame
 import math
 from particle import Particle
@@ -11,6 +15,8 @@ FPS = 60
 
 
 class CellWallApp:
+    """Simple app where particles can be dragged with the mouse."""
+
     def __init__(self):
         pygame.init()
         self.screen = pygame.display.set_mode(SCREEN_SIZE)

--- a/start_bending_wall.py
+++ b/start_bending_wall.py
@@ -1,3 +1,9 @@
+"""Demo of a triangular wall using springs and bending constraints.
+
+Keys D/F/G shorten selected springs while B/N/M toggle drag on
+corresponding particles. Other controls match those in ``start.py``.
+"""
+
 import pygame
 import math
 import random
@@ -15,6 +21,8 @@ FPS = 120
 
 
 class CellWallApp:
+    """Drag with the mouse and use D/F/G or B/N/M for spring and drag tweaks."""
+
     def __init__(self):
         pygame.init()
         self.screen = pygame.display.set_mode(SCREEN_SIZE)

--- a/start_four_rods.py
+++ b/start_four_rods.py
@@ -1,4 +1,9 @@
-# start_four_rods.py
+"""Four rod structures positioned around the centre of the screen.
+
+Use the same keyboard shortcuts as ``start.py`` to spawn particles and adjust
+simulation parameters.
+"""
+
 import math
 import random
 
@@ -15,6 +20,8 @@ FPS = 120
 
 
 class CellWallApp:
+    """Drag with the mouse; keyboard controls mirror those in start.py."""
+
     def __init__(self):
         pygame.init()
         self.screen = pygame.display.set_mode(SCREEN_SIZE)

--- a/start_gradient_wall.py
+++ b/start_gradient_wall.py
@@ -1,3 +1,9 @@
+"""Four rods coloured with an HSV gradient along their length.
+
+All keyboard controls are the same as in ``start.py`` for spawning and tweaking
+the simulation.
+"""
+
 import math
 import random
 import pygame
@@ -32,6 +38,8 @@ def get_gradient_color(t):
     return (int(r * 255), int(g * 255), int(b * 255))
 
 class CellWallApp:
+    """Drag particles and use keyboard shortcuts as in start.py."""
+
     def __init__(self):
         pygame.init()
         self.screen = pygame.display.set_mode(SCREEN_SIZE)

--- a/start_rod.py
+++ b/start_rod.py
@@ -1,4 +1,9 @@
-# main.py
+"""Capsule-like rod demo with controls matching ``start.py``.
+
+Particles can be spawned and simulation parameters tweaked using the keyboard
+shortcuts defined in the README.
+"""
+
 import math
 import random
 
@@ -19,6 +24,8 @@ FPS = 120
 
 
 class CellWallApp:
+    """Drag with the mouse and use O/P, K/L, N/M and Q/W keys like start.py."""
+
     def __init__(self):
         pygame.init()
         self.screen = pygame.display.set_mode(SCREEN_SIZE)


### PR DESCRIPTION
## Summary
- document keyboard controls and features in README
- add docstrings for demo modules
- describe interactive controls in the demo classes

## Testing
- `python3 -m py_compile start.py start_basic.py start_bending_wall.py start_four_rods.py start_gradient_wall.py start_rod.py`

------
https://chatgpt.com/codex/tasks/task_e_6888faea8f848325982e651ce7ced84a