### PR TITLE
Add high-drag indicator and cycle control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,8 @@ This repository contains small pygame demos for 2D particle-based physics simula
 - Keep the README up to date with instructions on running the demos and any changed controls or dependencies.
 
 There are no automated tests; run the demo scripts manually to verify behaviour.
+
+## Recent updates
+
+- High-drag particles render with a red outline to indicate adhesion.
+- Press **C** in `start_hook_arm.py` to run a full extend/adhere/contract cycle.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 ### Using high-drag particles
 
 Setting the ``tag`` attribute of a ``Particle`` to ``"high_drag"`` increases
-the drag force in ``PhysicsEngine.update``.  Demo scripts use this to simulate
+the drag force in ``PhysicsEngine.update``.  These particles are drawn with a
+red outline so their state is obvious. Demo scripts use this to simulate
 particles adhering to their surroundings—press **B/N/M** in
-``start_bending_wall.py`` or **H** in ``start_hook_arm.py`` to toggle the
-behaviour.
+``start_bending_wall.py`` or **H** (and now **C** for a full cycle) in
+``start_hook_arm.py`` to toggle the behaviour.
 
 ## Requirements
 
@@ -80,8 +81,9 @@ keyboard shortcuts:
   toggle high drag on selected particles.  All other controls from `start.py`
   are also available.
 * **`start_hook_arm.py`** – showcases a small flexible arm attached to a cell.
-  Hold **E** to extend the arm, **Q** to retract it and press **H** to toggle
-  adhesion (high drag) on the tip.
+  Hold **E** to extend the arm, **Q** to retract it, press **H** to toggle
+  adhesion on the tip or hit **C** to automatically extend, stick and
+  contract in one cycle. High‑drag particles are highlighted in red.
 * **`start_four_rods.py`** – four rods positioned around the centre with the
   same controls as `start.py`.
 * **`start_gradient_wall.py`** – similar to `start_four_rods.py` but colours each

--- a/renderer.py
+++ b/renderer.py
@@ -27,3 +27,11 @@ class Renderer:
             color = p.color if p.color else (0, 0, 255)
             radius = p.radius if p.radius else 10
             pygame.draw.circle(self.screen, color, (int(p.pos.x), int(p.pos.y)), radius=radius)
+            if getattr(p, "tag", "") == "high_drag":
+                pygame.draw.circle(
+                    self.screen,
+                    (255, 50, 50),
+                    (int(p.pos.x), int(p.pos.y)),
+                    radius + 4,
+                    width=2,
+                )

--- a/start_hook_arm.py
+++ b/start_hook_arm.py
@@ -61,7 +61,7 @@ class HookArmApp:
         self._set_high_drag(False)
 
         self.arm_rest_lengths = [s.rest_length for s in self.arm_springs]
-        self.arm_max = [rest * 4 for rest in self.arm_rest_lengths]
+        self.arm_max = [rest * 3 for rest in self.arm_rest_lengths]
 
         self.physics = PhysicsEngine(
             self.particles,
@@ -129,16 +129,16 @@ class HookArmApp:
 
             for i, s in enumerate(self.arm_springs):
                 if self.extend_held and s.rest_length < self.arm_max[i]:
-                    s.rest_length += 120 * dt
+                    s.rest_length += 240 * dt
                 if self.contract_held and s.rest_length > self.arm_rest_lengths[i]:
-                    s.rest_length -= 120 * dt
+                    s.rest_length -= 240 * dt
 
             if self.cycle_active:
                 if self.cycle_phase == 0:
                     done = True
                     for i, s in enumerate(self.arm_springs):
                         if s.rest_length < self.arm_max[i]:
-                            s.rest_length += 120 * dt
+                            s.rest_length += 240 * dt
                             done = False
                     if done:
                         for i, s in enumerate(self.arm_springs):
@@ -149,7 +149,7 @@ class HookArmApp:
                     done = True
                     for i, s in enumerate(self.arm_springs):
                         if s.rest_length > self.arm_rest_lengths[i]:
-                            s.rest_length -= 120 * dt
+                            s.rest_length -= 240 * dt
                             done = False
                     if done:
                         for i, s in enumerate(self.arm_springs):

--- a/start_hook_arm.py
+++ b/start_hook_arm.py
@@ -1,8 +1,13 @@
 """Demo of a cell with a flexible hook arm.
 
-Press **E** to extend the hook springs, **Q** to contract them and **H**
-to toggle high drag on the tip particle. Drag particles with the left
-mouse button.
+Controls:
+    - Hold **E** to extend the arm.
+    - Hold **Q** to retract it.
+    - Press **H** to toggle adhesion (high drag) on the tip.
+    - Press **C** to run a full extend/adhere/contract cycle.
+
+When a particle is in high-drag mode it is drawn in red so the adhesion
+state is visible. Drag particles with the left mouse button.
 """
 
 import pygame
@@ -30,6 +35,9 @@ class HookArmApp:
         self.arm_springs: list[Spring] = []
         self.selected = None
 
+        self.arm_color = (0, 150, 255)
+        self.high_drag_color = (255, 50, 50)
+
         center = pygame.Vector2(SCREEN_SIZE) / 2
         wall_particles, wall_springs = create_wall(center, radius=100, segments=40,
                                                    tag="cell", stiffness=2000)
@@ -43,13 +51,14 @@ class HookArmApp:
         prev = base
         for i in range(1, arm_segments + 1):
             pos = base.pos + pygame.Vector2(spacing * i, 0)
-            p = Particle(pos, mass=0.5, radius=8, color=(0, 150, 255), tag="arm")
+            p = Particle(pos, mass=0.5, radius=8, color=self.arm_color, tag="arm")
             self.particles.append(p)
             s = Spring(prev, p, rest_length=spacing, stiffness=500)
             self.springs.append(s)
             self.arm_springs.append(s)
             prev = p
         self.arm_tip = prev
+        self._set_high_drag(False)
 
         self.arm_rest_lengths = [s.rest_length for s in self.arm_springs]
         self.arm_max = [rest * 4 for rest in self.arm_rest_lengths]
@@ -68,6 +77,17 @@ class HookArmApp:
         self.clamp_to_window = True
         self.extend_held = False
         self.contract_held = False
+        self.cycle_active = False
+        self.cycle_phase = 0
+
+    def _set_high_drag(self, enabled: bool):
+        """Enable or disable high-drag mode on the arm tip."""
+        if enabled:
+            self.arm_tip.tag = "high_drag"
+            self.arm_tip.color = self.high_drag_color
+        else:
+            self.arm_tip.tag = "arm"
+            self.arm_tip.color = self.arm_color
 
     def run(self):
         running = True
@@ -90,10 +110,13 @@ class HookArmApp:
                     elif e.key == pygame.K_q:
                         self.contract_held = True
                     elif e.key == pygame.K_h:
-                        if getattr(self.arm_tip, "tag", "") == "high_drag":
-                            self.arm_tip.tag = "arm"
-                        else:
-                            self.arm_tip.tag = "high_drag"
+                        self._set_high_drag(getattr(self.arm_tip, "tag", "") != "high_drag")
+                    elif e.key == pygame.K_c:
+                        if not self.cycle_active:
+                            self.cycle_active = True
+                            self.cycle_phase = 0
+                            self.extend_held = False
+                            self.contract_held = False
                 elif e.type == pygame.KEYUP:
                     if e.key == pygame.K_e:
                         self.extend_held = False
@@ -109,6 +132,30 @@ class HookArmApp:
                     s.rest_length += 120 * dt
                 if self.contract_held and s.rest_length > self.arm_rest_lengths[i]:
                     s.rest_length -= 120 * dt
+
+            if self.cycle_active:
+                if self.cycle_phase == 0:
+                    done = True
+                    for i, s in enumerate(self.arm_springs):
+                        if s.rest_length < self.arm_max[i]:
+                            s.rest_length += 120 * dt
+                            done = False
+                    if done:
+                        for i, s in enumerate(self.arm_springs):
+                            s.rest_length = self.arm_max[i]
+                        self._set_high_drag(True)
+                        self.cycle_phase = 1
+                elif self.cycle_phase == 1:
+                    done = True
+                    for i, s in enumerate(self.arm_springs):
+                        if s.rest_length > self.arm_rest_lengths[i]:
+                            s.rest_length -= 120 * dt
+                            done = False
+                    if done:
+                        for i, s in enumerate(self.arm_springs):
+                            s.rest_length = self.arm_rest_lengths[i]
+                        self._set_high_drag(False)
+                        self.cycle_active = False
 
             self.physics.update(dt)
 


### PR DESCRIPTION
## Summary
- show a red outline when particles are in high drag
- colour change for tip in `start_hook_arm.py`
- allow **C** key to automatically extend, stick then contract the arm
- document new behaviour

## Testing
- `python start_hook_arm.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_688903eeaa3883258eaa847db0e3a36c