### PR TITLE
Add multi-arm cycle control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,10 @@ This repository contains small pygame demos for 2D particle-based physics simula
 - Keep the README up to date with instructions on running the demos and any changed controls or dependencies.
 
 There are no automated tests; run the demo scripts manually to verify behaviour.
+
+## Recent updates
+
+- High-drag particles render with a red outline to indicate adhesion.
+- `hook_arm.py` defines a reusable `HookArm` helper class.
+- `start_hook_arm.py` now features four arms; hold **W**, **A**, **S** or **D** to
+  run a continuous extend/adhere/contract cycle on the corresponding arm.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 ### Using high-drag particles
 
 Setting the ``tag`` attribute of a ``Particle`` to ``"high_drag"`` increases
-the drag force in ``PhysicsEngine.update``.  Demo scripts use this to simulate
+the drag force in ``PhysicsEngine.update``.  These particles are drawn with a
+red outline so their state is obvious. Demo scripts use this to simulate
 particles adhering to their surroundings—press **B/N/M** in
 ``start_bending_wall.py`` or **H** in ``start_hook_arm.py`` to toggle the
-behaviour.
+behaviour. Holding **W**, **A**, **S** or **D** in ``start_hook_arm.py`` runs a
+loop that extends, sticks and retracts an arm.
 
 ## Requirements
 
@@ -79,9 +81,11 @@ keyboard shortcuts:
   and **G** temporarily shorten individual springs while **B**, **N** and **M**
   toggle high drag on selected particles.  All other controls from `start.py`
   are also available.
-* **`start_hook_arm.py`** – showcases a small flexible arm attached to a cell.
-  Hold **E** to extend the arm, **Q** to retract it and press **H** to toggle
-  adhesion (high drag) on the tip.
+* **`start_hook_arm.py`** – showcases four flexible arms attached to a cell.
+  Hold **E** to extend all arms, **Q** to retract them, press **H** to toggle
+  adhesion on every tip or hold **W**, **A**, **S** or **D** to repeatedly
+  extend, stick and contract an individual arm. High‑drag particles are
+  highlighted in red.
 * **`start_four_rods.py`** – four rods positioned around the centre with the
   same controls as `start.py`.
 * **`start_gradient_wall.py`** – similar to `start_four_rods.py` but colours each

--- a/hook_arm.py
+++ b/hook_arm.py
@@ -1,0 +1,102 @@
+"""Helper class for a flexible hook arm.
+
+A HookArm is a small chain of particles attached to a base particle. Its
+springs can extend and contract, and the tip can enter a high-drag adhesion
+state. The class supports a cycling motion that repeatedly extends the arm,
+activates high drag and then retracts it.
+"""
+
+import pygame
+from particle import Particle
+from spring import Spring
+
+
+class HookArm:
+    """Represent a single flexible arm with simple control flags."""
+
+    def __init__(self, base: Particle, direction: pygame.Vector2,
+                 *, segments: int = 1, spacing: float = 50,
+                 stiffness: float = 500, color=(0, 150, 255),
+                 high_drag_color=(255, 50, 50)):
+        self.particles: list[Particle] = []
+        self.springs: list[Spring] = []
+        self.color = color
+        self.high_drag_color = high_drag_color
+
+        direction = direction.normalize()
+        prev = base
+        for i in range(1, segments + 1):
+            pos = base.pos + direction * spacing * i
+            p = Particle(pos, mass=0.5, radius=8, color=color, tag="arm")
+            self.particles.append(p)
+            s = Spring(prev, p, rest_length=spacing, stiffness=stiffness)
+            self.springs.append(s)
+            prev = p
+        self.tip = prev
+        self._set_high_drag(False)
+
+        self.rest_lengths = [s.rest_length for s in self.springs]
+        self.max_lengths = [r * 4 for r in self.rest_lengths]
+
+        self.extend_held = False
+        self.contract_held = False
+        self.cycle_held = False
+        self.cycle_active = False
+        self.cycle_phase = 0
+
+    def _set_high_drag(self, enabled: bool):
+        if enabled:
+            self.tip.tag = "high_drag"
+            self.tip.color = self.high_drag_color
+        else:
+            self.tip.tag = "arm"
+            self.tip.color = self.color
+
+    def reset_inert(self):
+        """Return the arm to its rest state with adhesion disabled."""
+        for i, s in enumerate(self.springs):
+            s.rest_length = self.rest_lengths[i]
+        self._set_high_drag(False)
+        self.cycle_active = False
+        self.cycle_phase = 0
+
+    def update(self, dt: float):
+        for i, s in enumerate(self.springs):
+            if self.extend_held and s.rest_length < self.max_lengths[i]:
+                s.rest_length += 120 * dt
+            if self.contract_held and s.rest_length > self.rest_lengths[i]:
+                s.rest_length -= 120 * dt
+
+        if self.cycle_held:
+            if not self.cycle_active:
+                self.cycle_active = True
+                self.cycle_phase = 0
+            if self.cycle_phase == 0:
+                done = True
+                for i, s in enumerate(self.springs):
+                    if s.rest_length < self.max_lengths[i]:
+                        s.rest_length += 120 * dt
+                        done = False
+                if done:
+                    for i, s in enumerate(self.springs):
+                        s.rest_length = self.max_lengths[i]
+                    self._set_high_drag(True)
+                    self.cycle_phase = 1
+            elif self.cycle_phase == 1:
+                done = True
+                for i, s in enumerate(self.springs):
+                    if s.rest_length > self.rest_lengths[i]:
+                        s.rest_length -= 120 * dt
+                        done = False
+                if done:
+                    for i, s in enumerate(self.springs):
+                        s.rest_length = self.rest_lengths[i]
+                    self._set_high_drag(False)
+                    # loop or finish depending on key state
+                    if self.cycle_held:
+                        self.cycle_phase = 0
+                    else:
+                        self.cycle_active = False
+        else:
+            if self.cycle_active:
+                self.reset_inert()

--- a/renderer.py
+++ b/renderer.py
@@ -27,3 +27,11 @@ class Renderer:
             color = p.color if p.color else (0, 0, 255)
             radius = p.radius if p.radius else 10
             pygame.draw.circle(self.screen, color, (int(p.pos.x), int(p.pos.y)), radius=radius)
+            if getattr(p, "tag", "") == "high_drag":
+                pygame.draw.circle(
+                    self.screen,
+                    (255, 50, 50),
+                    (int(p.pos.x), int(p.pos.y)),
+                    radius + 4,
+                    width=2,
+                )

--- a/start_hook_arm.py
+++ b/start_hook_arm.py
@@ -1,33 +1,35 @@
-"""Demo of a cell with a flexible hook arm.
+"""Demo of four flexible hook arms around a circular cell.
 
-Press **E** to extend the hook springs, **Q** to contract them and **H**
-to toggle high drag on the tip particle. Drag particles with the left
-mouse button.
+Hold **W**, **A**, **S** or **D** to cycle the matching arm through an
+extend/adhere/contract loop.  Releasing the key returns the arm to its
+rest state with adhesion disabled.  Keys **E**, **Q** and **H** still
+extend, contract or toggle adhesion on all arms simultaneously.
+
+High-drag particles draw with a red outline so adhesion is visible.
+Drag particles with the left mouse button.
 """
 
 import pygame
-import math
 
 from particle import Particle
 from physics import PhysicsEngine
 from renderer import Renderer
-from spring import Spring
 from structures import create_wall
+from hook_arm import HookArm
 
 SCREEN_SIZE = (1300, 900)
 FPS = 120
 
 
 class HookArmApp:
-    """Interactive demo of a single hook arm attached to a circular cell."""
+    """Interactive demo of multiple hook arms attached to a cell wall."""
 
     def __init__(self):
         pygame.init()
         self.screen = pygame.display.set_mode(SCREEN_SIZE)
         self.clock = pygame.time.Clock()
         self.particles: list[Particle] = []
-        self.springs: list[Spring] = []
-        self.arm_springs: list[Spring] = []
+        self.springs = []
         self.selected = None
 
         center = pygame.Vector2(SCREEN_SIZE) / 2
@@ -36,23 +38,16 @@ class HookArmApp:
         self.particles.extend(wall_particles)
         self.springs.extend(wall_springs)
 
-        # build a small chain as the hook arm
-        base = wall_particles[0]
-        arm_segments = 1
-        spacing = 50
-        prev = base
-        for i in range(1, arm_segments + 1):
-            pos = base.pos + pygame.Vector2(spacing * i, 0)
-            p = Particle(pos, mass=0.5, radius=8, color=(0, 150, 255), tag="arm")
-            self.particles.append(p)
-            s = Spring(prev, p, rest_length=spacing, stiffness=500)
-            self.springs.append(s)
-            self.arm_springs.append(s)
-            prev = p
-        self.arm_tip = prev
-
-        self.arm_rest_lengths = [s.rest_length for s in self.arm_springs]
-        self.arm_max = [rest * 4 for rest in self.arm_rest_lengths]
+        # Create four arms around the cell at 90-degree intervals
+        idx = [0, 10, 20, 30]
+        self.arms: list[HookArm] = []
+        for i in idx:
+            base = wall_particles[i]
+            direction = (base.pos - center).normalize()
+            arm = HookArm(base, direction)
+            self.arms.append(arm)
+            self.particles.extend(arm.particles)
+            self.springs.extend(arm.springs)
 
         self.physics = PhysicsEngine(
             self.particles,
@@ -66,8 +61,14 @@ class HookArmApp:
         self.renderer = Renderer(self.screen)
 
         self.clamp_to_window = True
-        self.extend_held = False
-        self.contract_held = False
+
+        # map keys to individual arms for cycling
+        self.cycle_keys = {
+            pygame.K_w: self.arms[0],
+            pygame.K_a: self.arms[1],
+            pygame.K_s: self.arms[2],
+            pygame.K_d: self.arms[3],
+        }
 
     def run(self):
         running = True
@@ -86,29 +87,34 @@ class HookArmApp:
                     self.selected = None
                 elif e.type == pygame.KEYDOWN:
                     if e.key == pygame.K_e:
-                        self.extend_held = True
+                        for arm in self.arms:
+                            arm.extend_held = True
                     elif e.key == pygame.K_q:
-                        self.contract_held = True
+                        for arm in self.arms:
+                            arm.contract_held = True
                     elif e.key == pygame.K_h:
-                        if getattr(self.arm_tip, "tag", "") == "high_drag":
-                            self.arm_tip.tag = "arm"
-                        else:
-                            self.arm_tip.tag = "high_drag"
+                        for arm in self.arms:
+                            arm._set_high_drag(getattr(arm.tip, "tag", "") != "high_drag")
+                    elif e.key in self.cycle_keys:
+                        self.cycle_keys[e.key].cycle_held = True
                 elif e.type == pygame.KEYUP:
                     if e.key == pygame.K_e:
-                        self.extend_held = False
+                        for arm in self.arms:
+                            arm.extend_held = False
                     elif e.key == pygame.K_q:
-                        self.contract_held = False
+                        for arm in self.arms:
+                            arm.contract_held = False
+                    elif e.key in self.cycle_keys:
+                        arm = self.cycle_keys[e.key]
+                        arm.cycle_held = False
+                        arm.reset_inert()
 
             if self.selected:
                 self.selected.pos = pygame.Vector2(pygame.mouse.get_pos())
                 self.selected.prev_pos = self.selected.pos.copy()
 
-            for i, s in enumerate(self.arm_springs):
-                if self.extend_held and s.rest_length < self.arm_max[i]:
-                    s.rest_length += 120 * dt
-                if self.contract_held and s.rest_length > self.arm_rest_lengths[i]:
-                    s.rest_length -= 120 * dt
+            for arm in self.arms:
+                arm.update(dt)
 
             self.physics.update(dt)
 


### PR DESCRIPTION
## Summary
- add `hook_arm.py` helper
- rework `start_hook_arm.py` with four arms
- cycle each arm while W/A/S/D are held
- document new controls

## Testing
- `python start_hook_arm.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_688903eeaa3883258eaa847db0e3a36c