### PR TITLE
Add weighted adhesion to HookArm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,4 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - `hook_arm.py` defines a reusable `HookArm` helper class.
 - `start_hook_arm.py` now features four arms; hold **W**, **A**, **S** or **D** to
   run a continuous extend/adhere/contract cycle on the corresponding arm.
+- The hook arm's tip becomes heavier while ``"high_drag"`` is active.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
   * `builder_ui.py` and `color_picker.py` – the sidebar widgets and the cross‑platform colour selection utility.
   * **High-drag adhesion** – set a particle's ``tag`` to ``"high_drag"`` and the
     physics engine multiplies its viscous drag, causing it to stick in place.
+  * **Weighted adhesion** – a ``HookArm`` tip also increases in mass when stuck
+    for extra grip.
   * **Adjustable springs** – spring rest lengths can be changed on the fly to
     mimic contracting or extending structures.
 
@@ -26,7 +28,8 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 
 Setting the ``tag`` attribute of a ``Particle`` to ``"high_drag"`` increases
 the drag force in ``PhysicsEngine.update``.  These particles are drawn with a
-red outline so their state is obvious. Demo scripts use this to simulate
+red outline so their state is obvious. ``HookArm`` also makes its tip heavier
+whenever high drag is enabled. Demo scripts use this to simulate
 particles adhering to their surroundings—press **B/N/M** in
 ``start_bending_wall.py`` or **H** in ``start_hook_arm.py`` to toggle the
 behaviour. Holding **W**, **A**, **S** or **D** in ``start_hook_arm.py`` runs a

--- a/hook_arm.py
+++ b/hook_arm.py
@@ -17,11 +17,34 @@ class HookArm:
     def __init__(self, base: Particle, direction: pygame.Vector2,
                  *, segments: int = 1, spacing: float = 50,
                  stiffness: float = 500, color=(0, 150, 255),
-                 high_drag_color=(255, 50, 50)):
+                 high_drag_color=(255, 50, 50),
+                 adhesion_mass_factor: float = 5.0):
+        """Create the arm anchored at ``base`` and pointing along ``direction``.
+
+        Parameters
+        ----------
+        base:
+            The particle the first segment attaches to.
+        direction:
+            Unit vector giving the initial arm direction.
+        segments:
+            Number of links making up the arm.
+        spacing:
+            Rest length between consecutive particles.
+        stiffness:
+            Spring stiffness for each connection.
+        color:
+            Default particle colour.
+        high_drag_color:
+            Colour used when the tip enters the high-drag state.
+        adhesion_mass_factor:
+            Multiplier applied to the tip's mass while adhesion is active.
+        """
         self.particles: list[Particle] = []
         self.springs: list[Spring] = []
         self.color = color
         self.high_drag_color = high_drag_color
+        self.adhesion_mass_factor = adhesion_mass_factor
 
         direction = direction.normalize()
         prev = base
@@ -33,6 +56,7 @@ class HookArm:
             self.springs.append(s)
             prev = p
         self.tip = prev
+        self._orig_mass = self.tip.mass
         self._set_high_drag(False)
 
         self.rest_lengths = [s.rest_length for s in self.springs]
@@ -48,9 +72,11 @@ class HookArm:
         if enabled:
             self.tip.tag = "high_drag"
             self.tip.color = self.high_drag_color
+            self.tip.mass = self._orig_mass * self.adhesion_mass_factor
         else:
             self.tip.tag = "arm"
             self.tip.color = self.color
+            self.tip.mass = self._orig_mass
 
     def reset_inert(self):
         """Return the arm to its rest state with adhesion disabled."""


### PR DESCRIPTION
## Summary
- make HookArm tip heavier when "high_drag" is enabled
- document weighted adhesion in README and AGENTS

## Testing
- `python start_hook_arm.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_688a0aa01a70832582ff9458441374c4