### PR TITLE
Add hook arm tool in builder UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,4 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
   max force and visibility.
 - The hook arm builder exposes fields for mass, radius, stiffness, colours and
   adhesion factor per arm.
+- Inspect tool uses ``0`` for spring max force to disable the limit and avoid errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,5 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - `start_hook_arm.py` now features four arms; hold **W**, **A**, **S** or **D** to
   run a continuous extend/adhere/contract cycle on the corresponding arm.
 - The hook arm's tip becomes heavier while ``"high_drag"`` is active.
+- `start_create.py` and `builder_ui.py` now let you attach hook arms and assign a
+  key for cycling them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,4 +48,5 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
   adhesion factor per arm.
 - Inspect tool uses ``0`` for spring max force to disable the limit and avoid errors.
 - Particle colour/mass/radius sliders and the spring stiffness slider only appear when their creation modes are active.
+- Particle, spring and environment controls now live behind separate sidebar buttons.
 - Hook arm creation now has a cycle speed slider controlling how fast the arm extends and retracts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,6 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - The hook arm's tip becomes heavier while ``"high_drag"`` is active.
 - `start_create.py` and `builder_ui.py` now let you attach hook arms and assign a
   key for cycling them.
+- Multiple hook arms can listen to the same cycle key.
+- A new **Inspect** mode lets you click a particle and modify its mass, radius
+  and colour through the sidebar.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,5 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - The hook arm builder exposes fields for mass, radius, stiffness, colours and
   adhesion factor per arm.
 - Inspect tool uses ``0`` for spring max force to disable the limit and avoid errors.
+- Particle colour/mass/radius sliders and the spring stiffness slider only appear when their creation modes are active.
+- Hook arm creation now has a cycle speed slider controlling how fast the arm extends and retracts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,7 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - Multiple hook arms can listen to the same cycle key.
 - A new **Inspect** mode lets you click a particle and modify its mass, radius
   and colour through the sidebar.
+- Inspect mode can now select springs to edit rest length, stiffness,
+  max force and visibility.
+- The hook arm builder exposes fields for mass, radius, stiffness, colours and
+  adhesion factor per arm.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 
 ## Features
 
-* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and temperature. Tools exist for circles, rods, flexible hook arms and an inspect mode for tweaking existing particles and springs.  Arm creation now exposes mass, radius, colour and adhesion settings per arm.
+* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and temperature. Tools exist for circles, rods, flexible hook arms and an inspect mode for tweaking existing particles and springs.  Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle and spring sliders only appear when their respective creation modes are selected.
 * **Demo scenes** – other `start_*.py` files showcase different preset configurations (e.g. cell walls, rods or gradient walls).  They are good starting points for custom experiments.
 * **Modular codebase** – the core simulation is split into small modules:
   * `particle.py` – a point mass implemented with Verlet integration.
@@ -67,7 +67,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **N/M** – decrease/increase simulation temperature
 * **P** – pause or resume the physics update
 
-Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. The sidebar fields let you set the arm's mass, radius, stiffness, colours and adhesion factor before creation, and any number of arms may share the same cycle key. The **Inspect** tool can select a particle or a spring so their properties (colour, mass, radius, rest length, stiffness, **max force** and visibility) may be edited in place.  A value of ``0`` for max force disables the limit.
+Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. The sidebar fields let you set the arm's mass, radius, stiffness, cycle speed, colours and adhesion factor before creation, and any number of arms may share the same cycle key. The **Inspect** tool can select a particle or a spring so their properties (colour, mass, radius, rest length, stiffness, **max force** and visibility) may be edited in place.  A value of ``0`` for max force disables the limit. Particle and spring sliders are hidden until their creation modes are chosen.
 
 ## Example demos
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 
 ## Features
 
-* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and temperature. Tools exist for circles, rods, flexible hook arms and an inspect mode for tweaking existing particles and springs.  Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle and spring sliders only appear when their respective creation modes are selected.
+* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and temperature. Tools exist for circles, rods, flexible hook arms and an inspect mode for tweaking existing particles and springs.  Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle, spring and environment controls each have their own button in the sidebar.
 * **Demo scenes** – other `start_*.py` files showcase different preset configurations (e.g. cell walls, rods or gradient walls).  They are good starting points for custom experiments.
 * **Modular codebase** – the core simulation is split into small modules:
   * `particle.py` – a point mass implemented with Verlet integration.
@@ -60,6 +60,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **5** – create rod structures
 * **6** – attach a hook arm to a particle
 * **7** – inspect an existing particle or spring
+* **8** – adjust environment settings (temperature)
 * **C** – choose a colour for newly created particles
 * **Z/X** – decrease/increase particle mass
 * **V/B** – decrease/increase particle radius
@@ -67,7 +68,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **N/M** – decrease/increase simulation temperature
 * **P** – pause or resume the physics update
 
-Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. The sidebar fields let you set the arm's mass, radius, stiffness, cycle speed, colours and adhesion factor before creation, and any number of arms may share the same cycle key. The **Inspect** tool can select a particle or a spring so their properties (colour, mass, radius, rest length, stiffness, **max force** and visibility) may be edited in place.  A value of ``0`` for max force disables the limit. Particle and spring sliders are hidden until their creation modes are chosen.
+Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. The sidebar fields let you set the arm's mass, radius, stiffness, cycle speed, colours and adhesion factor before creation, and any number of arms may share the same cycle key. The **Inspect** tool can select a particle or a spring so their properties (colour, mass, radius, rest length, stiffness, **max force** and visibility) may be edited in place.  A value of ``0`` for max force disables the limit. Use the Particle, Spring or Env buttons to reveal their respective sliders.
 
 ## Example demos
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 
 ## Features
 
-* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and temperature.
+* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and temperature. Tools exist for circles, rods and flexible hook arms.
 * **Demo scenes** – other `start_*.py` files showcase different preset configurations (e.g. cell walls, rods or gradient walls).  They are good starting points for custom experiments.
 * **Modular codebase** – the core simulation is split into small modules:
   * `particle.py` – a point mass implemented with Verlet integration.
@@ -58,6 +58,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **3** – connect two particles with a spring
 * **4** – delete the particle or spring under the cursor
 * **5** – create rod structures
+* **6** – attach a hook arm to a particle
 * **C** – choose a colour for newly created particles
 * **Z/X** – decrease/increase particle mass
 * **V/B** – decrease/increase particle radius
@@ -65,7 +66,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **N/M** – decrease/increase simulation temperature
 * **P** – pause or resume the physics update
 
-Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them.
+Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. Use the **Cycle** field to pick a keyboard key that will run the arm's extend/adhere/contract loop when held.
 
 ## Example demos
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **N/M** – decrease/increase simulation temperature
 * **P** – pause or resume the physics update
 
-Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. The sidebar fields let you set the arm's mass, radius, stiffness, colours and adhesion factor before creation, and any number of arms may share the same cycle key. The **Inspect** tool can select a particle or a spring so their properties (colour, mass, radius, rest length, stiffness and visibility) may be edited in place.
+Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. The sidebar fields let you set the arm's mass, radius, stiffness, colours and adhesion factor before creation, and any number of arms may share the same cycle key. The **Inspect** tool can select a particle or a spring so their properties (colour, mass, radius, rest length, stiffness, **max force** and visibility) may be edited in place.  A value of ``0`` for max force disables the limit.
 
 ## Example demos
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 
 ## Features
 
-* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and temperature. Tools exist for circles, rods and flexible hook arms.
+* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and temperature. Tools exist for circles, rods, flexible hook arms and an inspect mode for tweaking existing particles.
 * **Demo scenes** – other `start_*.py` files showcase different preset configurations (e.g. cell walls, rods or gradient walls).  They are good starting points for custom experiments.
 * **Modular codebase** – the core simulation is split into small modules:
   * `particle.py` – a point mass implemented with Verlet integration.
@@ -59,6 +59,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **4** – delete the particle or spring under the cursor
 * **5** – create rod structures
 * **6** – attach a hook arm to a particle
+* **7** – inspect an existing particle
 * **C** – choose a colour for newly created particles
 * **Z/X** – decrease/increase particle mass
 * **V/B** – decrease/increase particle radius
@@ -66,7 +67,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **N/M** – decrease/increase simulation temperature
 * **P** – pause or resume the physics update
 
-Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. Use the **Cycle** field to pick a keyboard key that will run the arm's extend/adhere/contract loop when held.
+Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. Use the **Cycle** field to pick a keyboard key that will run the arm's extend/adhere/contract loop when held; the same key can be assigned to multiple arms. The **Inspect** tool highlights a chosen particle so its colour, mass and radius can be modified using the sidebar fields.
 
 ## Example demos
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 
 ## Features
 
-* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and temperature. Tools exist for circles, rods, flexible hook arms and an inspect mode for tweaking existing particles.
+* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and temperature. Tools exist for circles, rods, flexible hook arms and an inspect mode for tweaking existing particles and springs.  Arm creation now exposes mass, radius, colour and adhesion settings per arm.
 * **Demo scenes** – other `start_*.py` files showcase different preset configurations (e.g. cell walls, rods or gradient walls).  They are good starting points for custom experiments.
 * **Modular codebase** – the core simulation is split into small modules:
   * `particle.py` – a point mass implemented with Verlet integration.
@@ -59,7 +59,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **4** – delete the particle or spring under the cursor
 * **5** – create rod structures
 * **6** – attach a hook arm to a particle
-* **7** – inspect an existing particle
+* **7** – inspect an existing particle or spring
 * **C** – choose a colour for newly created particles
 * **Z/X** – decrease/increase particle mass
 * **V/B** – decrease/increase particle radius
@@ -67,7 +67,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **N/M** – decrease/increase simulation temperature
 * **P** – pause or resume the physics update
 
-Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. Use the **Cycle** field to pick a keyboard key that will run the arm's extend/adhere/contract loop when held; the same key can be assigned to multiple arms. The **Inspect** tool highlights a chosen particle so its colour, mass and radius can be modified using the sidebar fields.
+Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. The sidebar fields let you set the arm's mass, radius, stiffness, colours and adhesion factor before creation, and any number of arms may share the same cycle key. The **Inspect** tool can select a particle or a spring so their properties (colour, mass, radius, rest length, stiffness and visibility) may be edited in place.
 
 ## Example demos
 

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -828,7 +828,9 @@ class InspectTool:
             self.spring.stiffness = max(10, value)
 
     def _get_max(self):
-        return self.spring.max_force if self.spring else 0
+        if not self.spring:
+            return 0
+        return self.spring.max_force if self.spring.max_force is not None else 0
 
     def _set_max(self, value: float):
         if self.spring:

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -546,7 +546,12 @@ class RodTool:
 
 
 class HookArmTool:
-    """Preview and creation helper for :class:`HookArm` instances."""
+    """Preview and creation helper for :class:`HookArm` instances.
+
+    The tool lets the user configure segment count, spacing, particle
+    mass/radius, spring stiffness, colours, adhesion factor and the key used
+    for cycling the arm.
+    """
 
     def __init__(self, sidebar: 'SidebarUI'):
         self.sidebar = sidebar
@@ -556,6 +561,12 @@ class HookArmTool:
         self.direction = pygame.Vector2(1, 0)
         self.segments = 3
         self.spacing = 20.0
+        self.mass = 0.5
+        self.radius = 8.0
+        self.stiffness = 500.0
+        self.color = (0, 150, 255)
+        self.high_drag_color = (255, 50, 50)
+        self.adhesion_factor = 10.0
         self.cycle_key = pygame.K_h
         self.dragging = False
 
@@ -571,6 +582,28 @@ class HookArmTool:
             "Spacing", 5, 60, lambda: self.spacing, self._set_spacing, x, y, width
         )
         y += 40
+        self.mass_field = SliderField(
+            "Mass", 0.1, 10.0, lambda: self.mass, self._set_mass, x, y, width
+        )
+        y += 40
+        self.radius_field = SliderField(
+            "Radius", 1, 50, lambda: self.radius, self._set_radius, x, y, width
+        )
+        y += 40
+        self.stiff_field = SliderField(
+            "Stiff", 10, 1000, lambda: self.stiffness, self._set_stiffness, x, y, width
+        )
+        y += 40
+        self.color_field = ColorField("Color", lambda: self.color, self._set_color, x, y, width)
+        y += 40
+        self.high_field = ColorField(
+            "HDrag", lambda: self.high_drag_color, self._set_high_color, x, y, width
+        )
+        y += 40
+        self.adh_field = SliderField(
+            "AdhesMF", 1, 20, lambda: self.adhesion_factor, self._set_adhesion, x, y, width
+        )
+        y += 40
         self.key_field = KeyField("Cycle", lambda: self.cycle_key, self._set_key, x, y, width)
         y += 40
         self.create_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
@@ -581,6 +614,24 @@ class HookArmTool:
 
     def _set_spacing(self, value: float):
         self.spacing = max(1, value)
+
+    def _set_mass(self, value: float):
+        self.mass = max(0.1, value)
+
+    def _set_radius(self, value: float):
+        self.radius = max(1, value)
+
+    def _set_stiffness(self, value: float):
+        self.stiffness = max(10, value)
+
+    def _set_color(self, color):
+        self.color = color
+
+    def _set_high_color(self, color):
+        self.high_drag_color = color
+
+    def _set_adhesion(self, value: float):
+        self.adhesion_factor = max(1, value)
 
     def _set_key(self, value: int | None):
         self.cycle_key = value
@@ -612,6 +663,12 @@ class HookArmTool:
             return
         self.seg_field.draw(self.sidebar.screen)
         self.space_field.draw(self.sidebar.screen)
+        self.mass_field.draw(self.sidebar.screen)
+        self.radius_field.draw(self.sidebar.screen)
+        self.stiff_field.draw(self.sidebar.screen)
+        self.color_field.draw(self.sidebar.screen)
+        self.high_field.draw(self.sidebar.screen)
+        self.adh_field.draw(self.sidebar.screen)
         self.key_field.draw(self.sidebar.screen)
         pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.create_rect)
         txt = self.sidebar.font.render("Create", True, (255, 255, 255))
@@ -626,7 +683,7 @@ class HookArmTool:
         last = self.base.pos
         for p in self._preview_points():
             pygame.draw.line(screen, color, last, p, 1)
-            pygame.draw.circle(screen, color, (int(p.x), int(p.y)), self.app.radius, 1)
+            pygame.draw.circle(screen, color, (int(p.x), int(p.y)), int(self.radius), 1)
             last = p
 
     # ---------------- event handling
@@ -639,6 +696,18 @@ class HookArmTool:
                 return True
             if self.space_field.handle_event(event):
                 return True
+            if self.mass_field.handle_event(event):
+                return True
+            if self.radius_field.handle_event(event):
+                return True
+            if self.stiff_field.handle_event(event):
+                return True
+            if self.color_field.handle_event(event):
+                return True
+            if self.high_field.handle_event(event):
+                return True
+            if self.adh_field.handle_event(event):
+                return True
             if self.key_field.handle_event(event):
                 return True
             if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
@@ -648,6 +717,12 @@ class HookArmTool:
                         self.direction,
                         self.segments,
                         self.spacing,
+                        self.mass,
+                        self.radius,
+                        self.stiffness,
+                        self.color,
+                        self.high_drag_color,
+                        self.adhesion_factor,
                         self.cycle_key,
                     )
                     self.cancel()
@@ -677,13 +752,14 @@ class HookArmTool:
 
 
 class InspectTool:
-    """Select a particle and edit its properties from the sidebar."""
+    """Select a particle or spring and edit its properties from the sidebar."""
 
     def __init__(self, sidebar: 'SidebarUI'):
         self.sidebar = sidebar
         self.app = sidebar.app
         self.active = False
         self.particle = None
+        self.spring = None
 
         x = sidebar.screen.get_width() - sidebar.WIDTH + 10
         width = sidebar.WIDTH - 20
@@ -700,6 +776,20 @@ class InspectTool:
         self.radius_field = SliderField(
             "P Radius", 1, 50, lambda: self._get_radius(), self._set_radius, x, y, width
         )
+        y += 40
+        self.rest_field = SliderField(
+            "S Rest", 1, 400, lambda: self._get_rest(), self._set_rest, x, y, width
+        )
+        y += 40
+        self.stiff_field = SliderField(
+            "S Stiff", 10, 1000, lambda: self._get_stiff(), self._set_stiff, x, y, width
+        )
+        y += 40
+        self.max_field = SliderField(
+            "S MaxF", 0, 2000, lambda: self._get_max(), self._set_max, x, y, width
+        )
+        y += 40
+        self.invis_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
 
     # ---------------- helpers
     def _get_color(self):
@@ -723,55 +813,136 @@ class InspectTool:
         if self.particle:
             self.particle.radius = max(1, int(value))
 
+    def _get_rest(self):
+        return self.spring.rest_length if self.spring else 0
+
+    def _set_rest(self, value: float):
+        if self.spring:
+            self.spring.rest_length = max(1, value)
+
+    def _get_stiff(self):
+        return self.spring.stiffness if self.spring else 0
+
+    def _set_stiff(self, value: float):
+        if self.spring:
+            self.spring.stiffness = max(10, value)
+
+    def _get_max(self):
+        return self.spring.max_force if self.spring else 0
+
+    def _set_max(self, value: float):
+        if self.spring:
+            self.spring.max_force = None if value == 0 else value
+
+    def _toggle_invisible(self):
+        if self.spring:
+            self.spring.invisible = not self.spring.invisible
+
     # ---------------- control
     def start(self):
         self.active = True
         self.particle = None
+        self.spring = None
 
     def cancel(self):
         self.active = False
         self.particle = None
+        self.spring = None
 
     # ---------------- drawing
     def draw_ui(self):
-        if not self.active or not self.sidebar.visible or not self.particle:
+        if not self.active or not self.sidebar.visible:
             return
-        self.color_field.draw(self.sidebar.screen)
-        self.mass_field.draw(self.sidebar.screen)
-        self.radius_field.draw(self.sidebar.screen)
+        if self.particle:
+            self.color_field.draw(self.sidebar.screen)
+            self.mass_field.draw(self.sidebar.screen)
+            self.radius_field.draw(self.sidebar.screen)
+        elif self.spring:
+            self.rest_field.draw(self.sidebar.screen)
+            self.stiff_field.draw(self.sidebar.screen)
+            self.max_field.draw(self.sidebar.screen)
+            pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.invis_rect)
+            txt = "Invisible" if self.spring.invisible else "Visible"
+            img = self.sidebar.font.render(txt, True, (255, 255, 255))
+            rect = img.get_rect(center=self.invis_rect.center)
+            self.sidebar.screen.blit(img, rect)
 
     def draw_preview(self):
-        if not self.active or not self.particle:
+        if not self.active:
             return
-        pygame.draw.circle(
-            self.sidebar.screen,
-            (255, 255, 0),
-            (int(self.particle.pos.x), int(self.particle.pos.y)),
-            int(self.particle.radius) + 4,
-            2,
-        )
+        if self.particle:
+            pygame.draw.circle(
+                self.sidebar.screen,
+                (255, 255, 0),
+                (int(self.particle.pos.x), int(self.particle.pos.y)),
+                int(self.particle.radius) + 4,
+                2,
+            )
+        elif self.spring:
+            pygame.draw.line(
+                self.sidebar.screen,
+                (255, 255, 0),
+                self.spring.p1.pos,
+                self.spring.p2.pos,
+                3,
+            )
 
     # ---------------- event handling
     def handle_event(self, event):
         if not self.active:
             return False
 
-        if self.sidebar.visible and self.particle:
-            if self.color_field.handle_event(event):
-                return True
-            if self.mass_field.handle_event(event):
-                return True
-            if self.radius_field.handle_event(event):
-                return True
+        if self.sidebar.visible:
+            if self.particle:
+                if self.color_field.handle_event(event):
+                    return True
+                if self.mass_field.handle_event(event):
+                    return True
+                if self.radius_field.handle_event(event):
+                    return True
+            elif self.spring:
+                if self.rest_field.handle_event(event):
+                    return True
+                if self.stiff_field.handle_event(event):
+                    return True
+                if self.max_field.handle_event(event):
+                    return True
+                if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1 and self.invis_rect.collidepoint(event.pos):
+                    self._toggle_invisible()
+                    return True
 
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             if event.pos[0] < self.sidebar.screen.get_width() - self.sidebar.visible_width():
+                mouse = pygame.Vector2(event.pos)
+                dist_p = float("inf")
+                dist_s = float("inf")
+                nearest_p = None
+                nearest_s = None
                 if self.app.particles:
-                    mouse = pygame.Vector2(event.pos)
-                    self.particle = min(
-                        self.app.particles, key=lambda p: (p.pos - mouse).length()
-                    )
-                    return True
+                    nearest_p = min(self.app.particles, key=lambda p: (p.pos - mouse).length())
+                    dist_p = (nearest_p.pos - mouse).length()
+                if self.app.springs:
+                    def seg_dist(s):
+                        a = s.p1.pos
+                        b = s.p2.pos
+                        d = b - a
+                        if d.length_squared() == 0:
+                            return (mouse - a).length()
+                        t = max(0, min(1, (mouse - a).dot(d) / d.length_squared()))
+                        proj = a + d * t
+                        return (mouse - proj).length()
+                    nearest_s = min(self.app.springs, key=seg_dist)
+                    dist_s = seg_dist(nearest_s)
+                if dist_p <= dist_s:
+                    if nearest_p is not None:
+                        self.particle = nearest_p
+                        self.spring = None
+                        return True
+                else:
+                    if nearest_s is not None:
+                        self.spring = nearest_s
+                        self.particle = None
+                        return True
 
         return False
 

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -549,8 +549,8 @@ class HookArmTool:
     """Preview and creation helper for :class:`HookArm` instances.
 
     The tool lets the user configure segment count, spacing, particle
-    mass/radius, spring stiffness, colours, adhesion factor and the key used
-    for cycling the arm.
+    mass/radius, spring stiffness, cycle speed, colours, adhesion factor and
+    the key used for cycling the arm.
     """
 
     def __init__(self, sidebar: 'SidebarUI'):
@@ -564,6 +564,7 @@ class HookArmTool:
         self.mass = 0.5
         self.radius = 8.0
         self.stiffness = 500.0
+        self.cycle_speed = 240.0
         self.color = (0, 150, 255)
         self.high_drag_color = (255, 50, 50)
         self.adhesion_factor = 10.0
@@ -592,6 +593,10 @@ class HookArmTool:
         y += 40
         self.stiff_field = SliderField(
             "Stiff", 10, 1000, lambda: self.stiffness, self._set_stiffness, x, y, width
+        )
+        y += 40
+        self.speed_field = SliderField(
+            "Speed", 50, 1000, lambda: self.cycle_speed, self._set_speed, x, y, width
         )
         y += 40
         self.color_field = ColorField("Color", lambda: self.color, self._set_color, x, y, width)
@@ -623,6 +628,9 @@ class HookArmTool:
 
     def _set_stiffness(self, value: float):
         self.stiffness = max(10, value)
+
+    def _set_speed(self, value: float):
+        self.cycle_speed = max(10, value)
 
     def _set_color(self, color):
         self.color = color
@@ -666,6 +674,7 @@ class HookArmTool:
         self.mass_field.draw(self.sidebar.screen)
         self.radius_field.draw(self.sidebar.screen)
         self.stiff_field.draw(self.sidebar.screen)
+        self.speed_field.draw(self.sidebar.screen)
         self.color_field.draw(self.sidebar.screen)
         self.high_field.draw(self.sidebar.screen)
         self.adh_field.draw(self.sidebar.screen)
@@ -702,6 +711,8 @@ class HookArmTool:
                 return True
             if self.stiff_field.handle_event(event):
                 return True
+            if self.speed_field.handle_event(event):
+                return True
             if self.color_field.handle_event(event):
                 return True
             if self.high_field.handle_event(event):
@@ -724,6 +735,7 @@ class HookArmTool:
                         self.high_drag_color,
                         self.adhesion_factor,
                         self.cycle_key,
+                        self.cycle_speed,
                     )
                     self.cancel()
                     self.sidebar.app.set_mode("drag")
@@ -962,6 +974,8 @@ class SidebarUI:
         self.buttons = []
         self.fields = []
         self.visible = True
+        self.particle_fields = []
+        self.spring_fields = []
         self.circle_tool = None
         self._setup_ui()
         # setup circle tool after computing layout
@@ -1000,20 +1014,25 @@ class SidebarUI:
             "Color", lambda: self.app.color, self.app.set_color, slider_x, y, slider_width
         )
         self.fields.append(color_field)
+        self.particle_fields.append(color_field)
         y += 40
-        self.fields.append(
-            SliderField("Mass", 0.1, 10.0, lambda: self.app.mass, self.app.set_mass, slider_x, y, slider_width)
+        mass_field = SliderField(
+            "Mass", 0.1, 10.0, lambda: self.app.mass, self.app.set_mass, slider_x, y, slider_width
         )
+        self.fields.append(mass_field)
+        self.particle_fields.append(mass_field)
         y += 40
-        self.fields.append(
-            SliderField("Radius", 1, 50, lambda: self.app.radius, self.app.set_radius, slider_x, y, slider_width)
+        radius_field = SliderField(
+            "Radius", 1, 50, lambda: self.app.radius, self.app.set_radius, slider_x, y, slider_width
         )
+        self.fields.append(radius_field)
+        self.particle_fields.append(radius_field)
         y += 40
-        self.fields.append(
-            SliderField(
-                "Stiff", 10, 1000, lambda: self.app.stiffness, self.app.set_stiffness, slider_x, y, slider_width
-            )
+        stiff_field = SliderField(
+            "Stiff", 10, 1000, lambda: self.app.stiffness, self.app.set_stiffness, slider_x, y, slider_width
         )
+        self.fields.append(stiff_field)
+        self.spring_fields.append(stiff_field)
         y += 40
         self.fields.append(
             SliderField(
@@ -1025,6 +1044,13 @@ class SidebarUI:
 
     def visible_width(self):
         return self.WIDTH if self.visible else 0
+
+    def _field_visible(self, field):
+        if field in self.particle_fields:
+            return self.app.mode == "particle"
+        if field in self.spring_fields:
+            return self.app.mode == "spring"
+        return True
 
     # ----------------------------------------------------------- draw
     def draw(self):
@@ -1045,7 +1071,8 @@ class SidebarUI:
                 self.screen.blit(text_img, text_rect)
 
             for field in self.fields:
-                field.draw(self.screen)
+                if self._field_visible(field):
+                    field.draw(self.screen)
 
             # extra UI from tools
             self.circle_tool.draw_ui()
@@ -1082,7 +1109,7 @@ class SidebarUI:
 
         if self.visible:
             for field in self.fields:
-                if field.handle_event(event):
+                if self._field_visible(field) and field.handle_event(event):
                     return True
 
         if self.circle_tool.handle_event(event):

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -166,6 +166,48 @@ class ColorField:
             pass
 
 
+class KeyField:
+    """Editable single-key input used for controlling hook arms."""
+
+    BOX_WIDTH = 60
+
+    def __init__(self, label, get_key, set_key, x, y, width):
+        self.label = label
+        self.get_key = get_key
+        self.set_key = set_key
+        self.font = pygame.font.SysFont(None, 22)
+
+        self.box_rect = pygame.Rect(x, y + 10, self.BOX_WIDTH, 22)
+        self.editing = False
+
+    def draw(self, screen):
+        key = self.get_key()
+        text = pygame.key.name(key) if key is not None else "None"
+        if self.editing:
+            text = f"[{text}]"
+
+        lbl = self.font.render(self.label, True, (255, 255, 255))
+        screen.blit(lbl, (self.box_rect.x, self.box_rect.y - 18))
+        pygame.draw.rect(screen, (255, 255, 255), self.box_rect, 1)
+        img = self.font.render(text, True, (255, 255, 255))
+        rect = img.get_rect(center=self.box_rect.center)
+        screen.blit(img, rect)
+
+    def handle_event(self, event):
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.box_rect.collidepoint(event.pos):
+                self.editing = True
+                return True
+        elif event.type == pygame.KEYDOWN and self.editing:
+            if event.key == pygame.K_ESCAPE:
+                self.set_key(None)
+            else:
+                self.set_key(event.key)
+            self.editing = False
+            return True
+        return False
+
+
 class CircleTool:
     """Handle circle preview creation with sliders and dragging."""
 
@@ -503,6 +545,137 @@ class RodTool:
         return False
 
 
+class HookArmTool:
+    """Preview and creation helper for :class:`HookArm` instances."""
+
+    def __init__(self, sidebar: 'SidebarUI'):
+        self.sidebar = sidebar
+        self.app = sidebar.app
+        self.active = False
+        self.base = None
+        self.direction = pygame.Vector2(1, 0)
+        self.segments = 3
+        self.spacing = 20.0
+        self.cycle_key = pygame.K_h
+        self.dragging = False
+
+        x = sidebar.screen.get_width() - sidebar.WIDTH + 10
+        width = sidebar.WIDTH - 20
+        y = sidebar.extra_start_y
+
+        self.seg_field = SliderField(
+            "Segments", 1, 10, lambda: self.segments, self._set_segments, x, y, width
+        )
+        y += 40
+        self.space_field = SliderField(
+            "Spacing", 5, 60, lambda: self.spacing, self._set_spacing, x, y, width
+        )
+        y += 40
+        self.key_field = KeyField("Cycle", lambda: self.cycle_key, self._set_key, x, y, width)
+        y += 40
+        self.create_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
+
+    # ---------------- value setters
+    def _set_segments(self, value: float):
+        self.segments = max(1, int(value))
+
+    def _set_spacing(self, value: float):
+        self.spacing = max(1, value)
+
+    def _set_key(self, value: int | None):
+        self.cycle_key = value
+
+    # ---------------- control
+    def start(self):
+        self.active = True
+        self.base = None
+
+    def cancel(self):
+        self.active = False
+        self.dragging = False
+
+    # ---------------- drawing helpers
+    def _preview_points(self):
+        if not self.base:
+            return []
+        if self.direction.length() == 0:
+            return []
+        dir_norm = self.direction.normalize()
+        pts = []
+        for i in range(1, self.segments + 1):
+            pos = self.base.pos + dir_norm * self.spacing * i
+            pts.append(pos)
+        return pts
+
+    def draw_ui(self):
+        if not self.active or not self.sidebar.visible:
+            return
+        self.seg_field.draw(self.sidebar.screen)
+        self.space_field.draw(self.sidebar.screen)
+        self.key_field.draw(self.sidebar.screen)
+        pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.create_rect)
+        txt = self.sidebar.font.render("Create", True, (255, 255, 255))
+        rect = txt.get_rect(center=self.create_rect.center)
+        self.sidebar.screen.blit(txt, rect)
+
+    def draw_preview(self):
+        if not self.active or not self.base:
+            return
+        screen = self.sidebar.screen
+        color = (150, 150, 150)
+        last = self.base.pos
+        for p in self._preview_points():
+            pygame.draw.line(screen, color, last, p, 1)
+            pygame.draw.circle(screen, color, (int(p.x), int(p.y)), self.app.radius, 1)
+            last = p
+
+    # ---------------- event handling
+    def handle_event(self, event):
+        if not self.active:
+            return False
+
+        if self.sidebar.visible:
+            if self.seg_field.handle_event(event):
+                return True
+            if self.space_field.handle_event(event):
+                return True
+            if self.key_field.handle_event(event):
+                return True
+            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                if self.create_rect.collidepoint(event.pos) and self.base:
+                    self.app.create_hook_arm(
+                        self.base,
+                        self.direction,
+                        self.segments,
+                        self.spacing,
+                        self.cycle_key,
+                    )
+                    self.cancel()
+                    self.sidebar.app.set_mode("drag")
+                    return True
+
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if event.pos[0] < self.sidebar.screen.get_width() - self.sidebar.visible_width():
+                mouse = pygame.Vector2(event.pos)
+                if not self.base:
+                    if self.app.particles:
+                        self.base = min(self.app.particles, key=lambda p: (p.pos - mouse).length())
+                        self.dragging = True
+                        self.direction = pygame.Vector2(1, 0)
+                        return True
+                else:
+                    self.dragging = True
+                    return True
+        elif event.type == pygame.MOUSEMOTION and self.dragging:
+            self.direction = pygame.Vector2(event.pos) - self.base.pos
+            return True
+        elif event.type == pygame.MOUSEBUTTONUP and event.button == 1 and self.dragging:
+            self.dragging = False
+            return True
+
+        return False
+
+
 class SidebarUI:
     BUTTON_HEIGHT = 28
     BUTTON_MARGIN = 4
@@ -521,6 +694,7 @@ class SidebarUI:
         # setup circle tool after computing layout
         self.circle_tool = CircleTool(self)
         self.rod_tool = RodTool(self)
+        self.arm_tool = HookArmTool(self)
 
     # ----------------------------------------------------------- setup
     def _setup_ui(self):
@@ -539,6 +713,7 @@ class SidebarUI:
         add_button("Spring", lambda: self.app.set_mode("spring"))
         add_button("Circle", lambda: self.app.set_mode("circle"))
         add_button("Rod", lambda: self.app.set_mode("rod"))
+        add_button("Arm", lambda: self.app.set_mode("arm"))
         add_button("Delete", lambda: self.app.set_mode("delete"))
         add_button(lambda: "Resume" if self.app.paused else "Pause", self.app.toggle_pause)
 
@@ -600,10 +775,12 @@ class SidebarUI:
             # extra UI from tools
             self.circle_tool.draw_ui()
             self.rod_tool.draw_ui()
+            self.arm_tool.draw_ui()
 
         # preview from tools (visible or not)
         self.circle_tool.draw_preview()
         self.rod_tool.draw_preview()
+        self.arm_tool.draw_preview()
 
         # toggle button (always visible)
         pygame.draw.rect(self.screen, (100, 100, 100), self.toggle_rect)
@@ -634,6 +811,8 @@ class SidebarUI:
         if self.circle_tool.handle_event(event):
             return True
         if self.rod_tool.handle_event(event):
+            return True
+        if self.arm_tool.handle_event(event):
             return True
 
         return False

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -676,6 +676,106 @@ class HookArmTool:
         return False
 
 
+class InspectTool:
+    """Select a particle and edit its properties from the sidebar."""
+
+    def __init__(self, sidebar: 'SidebarUI'):
+        self.sidebar = sidebar
+        self.app = sidebar.app
+        self.active = False
+        self.particle = None
+
+        x = sidebar.screen.get_width() - sidebar.WIDTH + 10
+        width = sidebar.WIDTH - 20
+        y = sidebar.extra_start_y
+
+        self.color_field = ColorField(
+            "P Color", lambda: self._get_color(), self._set_color, x, y, width
+        )
+        y += 40
+        self.mass_field = SliderField(
+            "P Mass", 0.1, 10.0, lambda: self._get_mass(), self._set_mass, x, y, width
+        )
+        y += 40
+        self.radius_field = SliderField(
+            "P Radius", 1, 50, lambda: self._get_radius(), self._set_radius, x, y, width
+        )
+
+    # ---------------- helpers
+    def _get_color(self):
+        return self.particle.color if self.particle else (255, 255, 255)
+
+    def _set_color(self, color):
+        if self.particle:
+            self.particle.color = color
+
+    def _get_mass(self):
+        return self.particle.mass if self.particle else 0
+
+    def _set_mass(self, value: float):
+        if self.particle:
+            self.particle.mass = max(0.1, value)
+
+    def _get_radius(self):
+        return self.particle.radius if self.particle else 0
+
+    def _set_radius(self, value: float):
+        if self.particle:
+            self.particle.radius = max(1, int(value))
+
+    # ---------------- control
+    def start(self):
+        self.active = True
+        self.particle = None
+
+    def cancel(self):
+        self.active = False
+        self.particle = None
+
+    # ---------------- drawing
+    def draw_ui(self):
+        if not self.active or not self.sidebar.visible or not self.particle:
+            return
+        self.color_field.draw(self.sidebar.screen)
+        self.mass_field.draw(self.sidebar.screen)
+        self.radius_field.draw(self.sidebar.screen)
+
+    def draw_preview(self):
+        if not self.active or not self.particle:
+            return
+        pygame.draw.circle(
+            self.sidebar.screen,
+            (255, 255, 0),
+            (int(self.particle.pos.x), int(self.particle.pos.y)),
+            int(self.particle.radius) + 4,
+            2,
+        )
+
+    # ---------------- event handling
+    def handle_event(self, event):
+        if not self.active:
+            return False
+
+        if self.sidebar.visible and self.particle:
+            if self.color_field.handle_event(event):
+                return True
+            if self.mass_field.handle_event(event):
+                return True
+            if self.radius_field.handle_event(event):
+                return True
+
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if event.pos[0] < self.sidebar.screen.get_width() - self.sidebar.visible_width():
+                if self.app.particles:
+                    mouse = pygame.Vector2(event.pos)
+                    self.particle = min(
+                        self.app.particles, key=lambda p: (p.pos - mouse).length()
+                    )
+                    return True
+
+        return False
+
+
 class SidebarUI:
     BUTTON_HEIGHT = 28
     BUTTON_MARGIN = 4
@@ -695,6 +795,7 @@ class SidebarUI:
         self.circle_tool = CircleTool(self)
         self.rod_tool = RodTool(self)
         self.arm_tool = HookArmTool(self)
+        self.inspect_tool = InspectTool(self)
 
     # ----------------------------------------------------------- setup
     def _setup_ui(self):
@@ -714,6 +815,7 @@ class SidebarUI:
         add_button("Circle", lambda: self.app.set_mode("circle"))
         add_button("Rod", lambda: self.app.set_mode("rod"))
         add_button("Arm", lambda: self.app.set_mode("arm"))
+        add_button("Inspect", lambda: self.app.set_mode("inspect"))
         add_button("Delete", lambda: self.app.set_mode("delete"))
         add_button(lambda: "Resume" if self.app.paused else "Pause", self.app.toggle_pause)
 
@@ -776,11 +878,13 @@ class SidebarUI:
             self.circle_tool.draw_ui()
             self.rod_tool.draw_ui()
             self.arm_tool.draw_ui()
+            self.inspect_tool.draw_ui()
 
         # preview from tools (visible or not)
         self.circle_tool.draw_preview()
         self.rod_tool.draw_preview()
         self.arm_tool.draw_preview()
+        self.inspect_tool.draw_preview()
 
         # toggle button (always visible)
         pygame.draw.rect(self.screen, (100, 100, 100), self.toggle_rect)
@@ -813,6 +917,8 @@ class SidebarUI:
         if self.rod_tool.handle_event(event):
             return True
         if self.arm_tool.handle_event(event):
+            return True
+        if self.inspect_tool.handle_event(event):
             return True
 
         return False

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -208,6 +208,146 @@ class KeyField:
         return False
 
 
+class ParticleTool:
+    """Handle options for creating new particles."""
+
+    def __init__(self, sidebar: 'SidebarUI'):
+        self.sidebar = sidebar
+        self.app = sidebar.app
+        self.active = False
+
+        x = sidebar.screen.get_width() - sidebar.WIDTH + 10
+        width = sidebar.WIDTH - 20
+        y = sidebar.extra_start_y
+
+        self.color_field = ColorField(
+            "Color", lambda: self.app.color, self.app.set_color, x, y, width
+        )
+        y += 40
+        self.mass_field = SliderField(
+            "Mass", 0.1, 10.0, lambda: self.app.mass, self.app.set_mass, x, y, width
+        )
+        y += 40
+        self.radius_field = SliderField(
+            "Radius", 1, 50, lambda: self.app.radius, self.app.set_radius, x, y, width
+        )
+
+    # ---------------- control
+    def start(self):
+        self.active = True
+
+    def cancel(self):
+        self.active = False
+
+    # ---------------- drawing
+    def draw_ui(self):
+        if not self.active or not self.sidebar.visible:
+            return
+        self.color_field.draw(self.sidebar.screen)
+        self.mass_field.draw(self.sidebar.screen)
+        self.radius_field.draw(self.sidebar.screen)
+
+    def draw_preview(self):
+        pass
+
+    # ---------------- event handling
+    def handle_event(self, event):
+        if not self.active:
+            return False
+        if self.sidebar.visible:
+            if self.color_field.handle_event(event):
+                return True
+            if self.mass_field.handle_event(event):
+                return True
+            if self.radius_field.handle_event(event):
+                return True
+        return False
+
+
+class SpringTool:
+    """Handle spring stiffness options when creating new springs."""
+
+    def __init__(self, sidebar: 'SidebarUI'):
+        self.sidebar = sidebar
+        self.app = sidebar.app
+        self.active = False
+
+        x = sidebar.screen.get_width() - sidebar.WIDTH + 10
+        width = sidebar.WIDTH - 20
+        y = sidebar.extra_start_y
+
+        self.stiff_field = SliderField(
+            "Stiff", 10, 1000, lambda: self.app.stiffness, self.app.set_stiffness, x, y, width
+        )
+
+    # ---------------- control
+    def start(self):
+        self.active = True
+
+    def cancel(self):
+        self.active = False
+
+    # ---------------- drawing
+    def draw_ui(self):
+        if not self.active or not self.sidebar.visible:
+            return
+        self.stiff_field.draw(self.sidebar.screen)
+
+    def draw_preview(self):
+        pass
+
+    # ---------------- event handling
+    def handle_event(self, event):
+        if not self.active:
+            return False
+        if self.sidebar.visible:
+            if self.stiff_field.handle_event(event):
+                return True
+        return False
+
+
+class EnvironmentTool:
+    """Expose global simulation options such as temperature."""
+
+    def __init__(self, sidebar: 'SidebarUI'):
+        self.sidebar = sidebar
+        self.app = sidebar.app
+        self.active = False
+
+        x = sidebar.screen.get_width() - sidebar.WIDTH + 10
+        width = sidebar.WIDTH - 20
+        y = sidebar.extra_start_y
+
+        self.temp_field = SliderField(
+            "Temp", 0, 1000, lambda: self.app.physics.temperature, self.app.set_temperature, x, y, width
+        )
+
+    # ---------------- control
+    def start(self):
+        self.active = True
+
+    def cancel(self):
+        self.active = False
+
+    # ---------------- drawing
+    def draw_ui(self):
+        if not self.active or not self.sidebar.visible:
+            return
+        self.temp_field.draw(self.sidebar.screen)
+
+    def draw_preview(self):
+        pass
+
+    # ---------------- event handling
+    def handle_event(self, event):
+        if not self.active:
+            return False
+        if self.sidebar.visible:
+            if self.temp_field.handle_event(event):
+                return True
+        return False
+
+
 class CircleTool:
     """Handle circle preview creation with sliders and dragging."""
 
@@ -974,14 +1114,15 @@ class SidebarUI:
         self.buttons = []
         self.fields = []
         self.visible = True
-        self.particle_fields = []
-        self.spring_fields = []
         self.circle_tool = None
         self._setup_ui()
         # setup circle tool after computing layout
+        self.particle_tool = ParticleTool(self)
+        self.spring_tool = SpringTool(self)
         self.circle_tool = CircleTool(self)
         self.rod_tool = RodTool(self)
         self.arm_tool = HookArmTool(self)
+        self.env_tool = EnvironmentTool(self)
         self.inspect_tool = InspectTool(self)
 
     # ----------------------------------------------------------- setup
@@ -1003,54 +1144,15 @@ class SidebarUI:
         add_button("Rod", lambda: self.app.set_mode("rod"))
         add_button("Arm", lambda: self.app.set_mode("arm"))
         add_button("Inspect", lambda: self.app.set_mode("inspect"))
+        add_button("Env", lambda: self.app.set_mode("env"))
         add_button("Delete", lambda: self.app.set_mode("delete"))
         add_button(lambda: "Resume" if self.app.paused else "Pause", self.app.toggle_pause)
 
-        # sliders
-        slider_x = sw - self.WIDTH + 10
-        slider_width = self.WIDTH - 20
         y += 10
-        color_field = ColorField(
-            "Color", lambda: self.app.color, self.app.set_color, slider_x, y, slider_width
-        )
-        self.fields.append(color_field)
-        self.particle_fields.append(color_field)
-        y += 40
-        mass_field = SliderField(
-            "Mass", 0.1, 10.0, lambda: self.app.mass, self.app.set_mass, slider_x, y, slider_width
-        )
-        self.fields.append(mass_field)
-        self.particle_fields.append(mass_field)
-        y += 40
-        radius_field = SliderField(
-            "Radius", 1, 50, lambda: self.app.radius, self.app.set_radius, slider_x, y, slider_width
-        )
-        self.fields.append(radius_field)
-        self.particle_fields.append(radius_field)
-        y += 40
-        stiff_field = SliderField(
-            "Stiff", 10, 1000, lambda: self.app.stiffness, self.app.set_stiffness, slider_x, y, slider_width
-        )
-        self.fields.append(stiff_field)
-        self.spring_fields.append(stiff_field)
-        y += 40
-        self.fields.append(
-            SliderField(
-                "Temp", 0, 1000, lambda: self.app.physics.temperature, self.app.set_temperature, slider_x, y, slider_width
-            )
-        )
-        y += 40
         self.extra_start_y = y
 
     def visible_width(self):
         return self.WIDTH if self.visible else 0
-
-    def _field_visible(self, field):
-        if field in self.particle_fields:
-            return self.app.mode == "particle"
-        if field in self.spring_fields:
-            return self.app.mode == "spring"
-        return True
 
     # ----------------------------------------------------------- draw
     def draw(self):
@@ -1071,19 +1173,24 @@ class SidebarUI:
                 self.screen.blit(text_img, text_rect)
 
             for field in self.fields:
-                if self._field_visible(field):
-                    field.draw(self.screen)
+                field.draw(self.screen)
 
             # extra UI from tools
+            self.particle_tool.draw_ui()
+            self.spring_tool.draw_ui()
             self.circle_tool.draw_ui()
             self.rod_tool.draw_ui()
             self.arm_tool.draw_ui()
+            self.env_tool.draw_ui()
             self.inspect_tool.draw_ui()
 
         # preview from tools (visible or not)
+        self.particle_tool.draw_preview()
+        self.spring_tool.draw_preview()
         self.circle_tool.draw_preview()
         self.rod_tool.draw_preview()
         self.arm_tool.draw_preview()
+        self.env_tool.draw_preview()
         self.inspect_tool.draw_preview()
 
         # toggle button (always visible)
@@ -1109,14 +1216,20 @@ class SidebarUI:
 
         if self.visible:
             for field in self.fields:
-                if self._field_visible(field) and field.handle_event(event):
+                if field.handle_event(event):
                     return True
 
+        if self.particle_tool.handle_event(event):
+            return True
+        if self.spring_tool.handle_event(event):
+            return True
         if self.circle_tool.handle_event(event):
             return True
         if self.rod_tool.handle_event(event):
             return True
         if self.arm_tool.handle_event(event):
+            return True
+        if self.env_tool.handle_event(event):
             return True
         if self.inspect_tool.handle_event(event):
             return True

--- a/hook_arm.py
+++ b/hook_arm.py
@@ -14,11 +14,20 @@ from spring import Spring
 class HookArm:
     """Represent a single flexible arm with simple control flags."""
 
-    def __init__(self, base: Particle, direction: pygame.Vector2,
-                 *, segments: int = 1, spacing: float = 20,
-                 stiffness: float = 500, color=(0, 150, 255),
-                 high_drag_color=(255, 50, 50),
-                 adhesion_mass_factor: float = 10.0):
+    def __init__(
+        self,
+        base: Particle,
+        direction: pygame.Vector2,
+        *,
+        segments: int = 1,
+        spacing: float = 20,
+        stiffness: float = 500,
+        color=(0, 150, 255),
+        high_drag_color=(255, 50, 50),
+        adhesion_mass_factor: float = 10.0,
+        mass: float = 0.5,
+        radius: float = 8,
+    ):
         """Create the arm anchored at ``base`` and pointing along ``direction``.
 
         Parameters
@@ -39,6 +48,10 @@ class HookArm:
             Colour used when the tip enters the high-drag state.
         adhesion_mass_factor:
             Multiplier applied to the tip's mass while adhesion is active.
+        mass:
+            Particle mass for each link in the arm.
+        radius:
+            Particle radius for each link in the arm.
         """
         self.particles: list[Particle] = []
         self.springs: list[Spring] = []
@@ -50,7 +63,7 @@ class HookArm:
         prev = base
         for i in range(1, segments + 1):
             pos = base.pos + direction * spacing * i
-            p = Particle(pos, mass=0.5, radius=8, color=color, tag="arm")
+            p = Particle(pos, mass=mass, radius=radius, color=color, tag="arm")
             self.particles.append(p)
             s = Spring(prev, p, rest_length=spacing, stiffness=stiffness)
             self.springs.append(s)

--- a/hook_arm.py
+++ b/hook_arm.py
@@ -27,6 +27,7 @@ class HookArm:
         adhesion_mass_factor: float = 10.0,
         mass: float = 0.5,
         radius: float = 8,
+        cycle_speed: float = 240.0,
     ):
         """Create the arm anchored at ``base`` and pointing along ``direction``.
 
@@ -52,12 +53,15 @@ class HookArm:
             Particle mass for each link in the arm.
         radius:
             Particle radius for each link in the arm.
+        cycle_speed:
+            Rate at which the arm extends and contracts when cycling.
         """
         self.particles: list[Particle] = []
         self.springs: list[Spring] = []
         self.color = color
         self.high_drag_color = high_drag_color
         self.adhesion_mass_factor = adhesion_mass_factor
+        self.cycle_speed = cycle_speed
 
         direction = direction.normalize()
         prev = base
@@ -102,9 +106,9 @@ class HookArm:
     def update(self, dt: float):
         for i, s in enumerate(self.springs):
             if self.extend_held and s.rest_length < self.max_lengths[i]:
-                s.rest_length += 240 * dt
+                s.rest_length += self.cycle_speed * dt
             if self.contract_held and s.rest_length > self.rest_lengths[i]:
-                s.rest_length -= 240 * dt
+                s.rest_length -= self.cycle_speed * dt
 
         if self.cycle_held:
             if not self.cycle_active:
@@ -114,7 +118,7 @@ class HookArm:
                 done = True
                 for i, s in enumerate(self.springs):
                     if s.rest_length < self.max_lengths[i]:
-                        s.rest_length += 240 * dt
+                        s.rest_length += self.cycle_speed * dt
                         done = False
                 if done:
                     for i, s in enumerate(self.springs):
@@ -125,7 +129,7 @@ class HookArm:
                 done = True
                 for i, s in enumerate(self.springs):
                     if s.rest_length > self.rest_lengths[i]:
-                        s.rest_length -= 240 * dt
+                        s.rest_length -= self.cycle_speed * dt
                         done = False
                 if done:
                     for i, s in enumerate(self.springs):

--- a/start_create.py
+++ b/start_create.py
@@ -151,6 +151,12 @@ class BuilderApp:
         direction: pygame.Vector2,
         segments: int,
         spacing: float,
+        mass: float,
+        radius: float,
+        stiffness: float,
+        color,
+        high_drag_color,
+        adhesion_factor: float,
         cycle_key: int | None,
     ):
         """Attach a new :class:`HookArm` to ``base`` and register its cycle key."""
@@ -159,8 +165,12 @@ class BuilderApp:
             direction if direction.length() > 0 else pygame.Vector2(1, 0),
             segments=segments,
             spacing=spacing,
-            stiffness=self.stiffness,
-            color=self.color,
+            stiffness=stiffness,
+            color=color,
+            high_drag_color=high_drag_color,
+            adhesion_mass_factor=adhesion_factor,
+            mass=mass,
+            radius=radius,
         )
         arm.cycle_key = cycle_key
         if cycle_key is not None:

--- a/start_create.py
+++ b/start_create.py
@@ -58,6 +58,12 @@ class BuilderApp:
             self.ui.arm_tool.cancel()
         if self.mode == "inspect" and mode != "inspect":
             self.ui.inspect_tool.cancel()
+        if self.mode == "particle" and mode != "particle":
+            self.ui.particle_tool.cancel()
+        if self.mode == "spring" and mode != "spring":
+            self.ui.spring_tool.cancel()
+        if self.mode == "env" and mode != "env":
+            self.ui.env_tool.cancel()
 
         self.mode = mode
         if mode == "circle":
@@ -68,6 +74,12 @@ class BuilderApp:
             self.ui.arm_tool.start()
         if mode == "inspect":
             self.ui.inspect_tool.start()
+        if mode == "particle":
+            self.ui.particle_tool.start()
+        if mode == "spring":
+            self.ui.spring_tool.start()
+        if mode == "env":
+            self.ui.env_tool.start()
         if mode != "spring":
             self.spring_first = None
         if self.selected and mode != "drag":
@@ -240,6 +252,8 @@ class BuilderApp:
                         self.set_mode("arm")
                     elif e.key == pygame.K_7:
                         self.set_mode("inspect")
+                    elif e.key == pygame.K_8:
+                        self.set_mode("env")
                     elif e.key == pygame.K_c:
                         self.choose_color()
                     elif e.key == pygame.K_z:

--- a/start_create.py
+++ b/start_create.py
@@ -23,7 +23,7 @@ class BuilderApp:
         self.particles: list[Particle] = []
         self.springs: list[Spring] = []
         self.arms: list[HookArm] = []
-        self.cycle_keys: dict[int, HookArm] = {}
+        self.cycle_keys: dict[int, list[HookArm]] = {}
         self.selected = None
         self.spring_first = None
         self.paused = False
@@ -56,6 +56,8 @@ class BuilderApp:
             self.ui.rod_tool.cancel()
         if self.mode == "arm" and mode != "arm":
             self.ui.arm_tool.cancel()
+        if self.mode == "inspect" and mode != "inspect":
+            self.ui.inspect_tool.cancel()
 
         self.mode = mode
         if mode == "circle":
@@ -64,6 +66,8 @@ class BuilderApp:
             self.ui.rod_tool.start()
         if mode == "arm":
             self.ui.arm_tool.start()
+        if mode == "inspect":
+            self.ui.inspect_tool.start()
         if mode != "spring":
             self.spring_first = None
         if self.selected and mode != "drag":
@@ -160,7 +164,7 @@ class BuilderApp:
         )
         arm.cycle_key = cycle_key
         if cycle_key is not None:
-            self.cycle_keys[cycle_key] = arm
+            self.cycle_keys.setdefault(cycle_key, []).append(arm)
         self.arms.append(arm)
         self.particles.extend(arm.particles)
         self.springs.extend(arm.springs)
@@ -222,6 +226,8 @@ class BuilderApp:
                         self.set_mode("rod")
                     elif e.key == pygame.K_6:
                         self.set_mode("arm")
+                    elif e.key == pygame.K_7:
+                        self.set_mode("inspect")
                     elif e.key == pygame.K_c:
                         self.choose_color()
                     elif e.key == pygame.K_z:
@@ -245,13 +251,13 @@ class BuilderApp:
                     elif e.key == pygame.K_ESCAPE:
                         self.spring_first = None
                     else:
-                        arm = self.cycle_keys.get(e.key)
-                        if arm:
+                        arms = self.cycle_keys.get(e.key, [])
+                        for arm in arms:
                             arm.cycle_held = True
 
                 elif e.type == pygame.KEYUP:
-                    arm = self.cycle_keys.get(e.key)
-                    if arm:
+                    arms = self.cycle_keys.get(e.key, [])
+                    for arm in arms:
                         arm.cycle_held = False
                         arm.reset_inert()
 

--- a/start_create.py
+++ b/start_create.py
@@ -158,6 +158,7 @@ class BuilderApp:
         high_drag_color,
         adhesion_factor: float,
         cycle_key: int | None,
+        cycle_speed: float,
     ):
         """Attach a new :class:`HookArm` to ``base`` and register its cycle key."""
         arm = HookArm(
@@ -171,6 +172,7 @@ class BuilderApp:
             adhesion_mass_factor=adhesion_factor,
             mass=mass,
             radius=radius,
+            cycle_speed=cycle_speed,
         )
         arm.cycle_key = cycle_key
         if cycle_key is not None:

--- a/start_create.py
+++ b/start_create.py
@@ -7,6 +7,7 @@ from physics import PhysicsEngine
 from renderer import Renderer
 from builder_ui import SidebarUI
 from structures import create_rod as structure_create_rod
+from hook_arm import HookArm
 
 SCREEN_SIZE = (1300, 900)
 FPS = 120
@@ -21,6 +22,8 @@ class BuilderApp:
         self.clock = pygame.time.Clock()
         self.particles: list[Particle] = []
         self.springs: list[Spring] = []
+        self.arms: list[HookArm] = []
+        self.cycle_keys: dict[int, HookArm] = {}
         self.selected = None
         self.spring_first = None
         self.paused = False
@@ -51,12 +54,16 @@ class BuilderApp:
             self.ui.circle_tool.cancel()
         if self.mode == "rod" and mode != "rod":
             self.ui.rod_tool.cancel()
+        if self.mode == "arm" and mode != "arm":
+            self.ui.arm_tool.cancel()
 
         self.mode = mode
         if mode == "circle":
             self.ui.circle_tool.start()
         if mode == "rod":
             self.ui.rod_tool.start()
+        if mode == "arm":
+            self.ui.arm_tool.start()
         if mode != "spring":
             self.spring_first = None
         if self.selected and mode != "drag":
@@ -134,6 +141,30 @@ class BuilderApp:
         self.particles.extend(particles)
         self.springs.extend(springs)
 
+    def create_hook_arm(
+        self,
+        base: Particle,
+        direction: pygame.Vector2,
+        segments: int,
+        spacing: float,
+        cycle_key: int | None,
+    ):
+        """Attach a new :class:`HookArm` to ``base`` and register its cycle key."""
+        arm = HookArm(
+            base,
+            direction if direction.length() > 0 else pygame.Vector2(1, 0),
+            segments=segments,
+            spacing=spacing,
+            stiffness=self.stiffness,
+            color=self.color,
+        )
+        arm.cycle_key = cycle_key
+        if cycle_key is not None:
+            self.cycle_keys[cycle_key] = arm
+        self.arms.append(arm)
+        self.particles.extend(arm.particles)
+        self.springs.extend(arm.springs)
+
     def create_rod(
         self,
         center: pygame.Vector2,
@@ -189,6 +220,8 @@ class BuilderApp:
                         self.set_mode("delete")
                     elif e.key == pygame.K_5:
                         self.set_mode("rod")
+                    elif e.key == pygame.K_6:
+                        self.set_mode("arm")
                     elif e.key == pygame.K_c:
                         self.choose_color()
                     elif e.key == pygame.K_z:
@@ -211,6 +244,16 @@ class BuilderApp:
                         self.toggle_pause()
                     elif e.key == pygame.K_ESCAPE:
                         self.spring_first = None
+                    else:
+                        arm = self.cycle_keys.get(e.key)
+                        if arm:
+                            arm.cycle_held = True
+
+                elif e.type == pygame.KEYUP:
+                    arm = self.cycle_keys.get(e.key)
+                    if arm:
+                        arm.cycle_held = False
+                        arm.reset_inert()
 
                 elif e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
                     mouse = pygame.Vector2(e.pos)
@@ -262,6 +305,8 @@ class BuilderApp:
                             self.springs.remove(target_s)
                     elif self.mode == "rod":
                         pass  # handled by rod tool
+                    elif self.mode == "arm":
+                        pass  # handled by arm tool
 
                 elif e.type == pygame.MOUSEBUTTONUP and e.button == 1:
                     if self.selected:
@@ -274,6 +319,8 @@ class BuilderApp:
 
             if not self.paused:
                 self.physics.update(dt)
+                for arm in self.arms:
+                    arm.update(dt)
 
             # keep particles inside the window and out of the sidebar
             max_x = self.screen.get_width() - self.ui.visible_width()


### PR DESCRIPTION
## Summary
- integrate KeyField helper for setting cycle keys
- add HookArmTool to builder_ui for creating hook arms
- allow adding hook arms in start_create and map keys to cycle motion
- document arm mode in README
- note new feature in AGENTS

## Testing
- `python -m py_compile builder_ui.py start_create.py hook_arm.py`
- `SDL_VIDEODRIVER=dummy python start_create.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_688a17493fac832583923fc6d876705c