### PR TITLE
Add particle orientation and orientation spring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,6 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - Particle, spring and environment controls now live behind separate sidebar buttons.
 - Hook arm creation now has a cycle speed slider controlling how fast the arm extends and retracts.
 - Particles may track an optional orientation angle. ``OrientationSpring`` keeps
-  a particle aligned with a spring and the renderer draws a yellow dot only when
-  orientation is enabled. The builder UI includes a toggle to set this on newly
-  created or selected particles.
+  a particle aligned with a spring and the renderer draws a yellow line only
+  when orientation is enabled. The builder UI includes a toggle to set this on
+  newly created or selected particles.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,5 +51,7 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - Particle colour/mass/radius sliders and the spring stiffness slider only appear when their creation modes are active.
 - Particle, spring and environment controls now live behind separate sidebar buttons.
 - Hook arm creation now has a cycle speed slider controlling how fast the arm extends and retracts.
-- Particles now store an orientation angle. ``OrientationSpring`` ties this angle
-  to a spring and the renderer draws a yellow indicator showing the direction.
+- Particles may track an optional orientation angle. ``OrientationSpring`` keeps
+  a particle aligned with a spring and the renderer draws a yellow dot only when
+  orientation is enabled. The builder UI includes a toggle to set this on newly
+  created or selected particles.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This repository contains small pygame demos for 2D particle-based physics simula
 - `particle.py` – Particle class using Verlet integration.
 - `spring.py` – linear spring connecting two particles.
 - `bending_spring.py` – bending constraint that keeps an angle between three particles.
+- `OrientationSpring` in `bending_spring.py` – aligns a particle's angle with a connected spring.
 - `physics.py` – `PhysicsEngine` that applies forces, drag and Brownian noise.
 - `renderer.py` – draws particles and springs to the screen.
 - `structures.py` – helper routines for building walls, rods and other shapes.
@@ -50,3 +51,5 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - Particle colour/mass/radius sliders and the spring stiffness slider only appear when their creation modes are active.
 - Particle, spring and environment controls now live behind separate sidebar buttons.
 - Hook arm creation now has a cycle speed slider controlling how fast the arm extends and retracts.
+- Particles now store an orientation angle. ``OrientationSpring`` ties this angle
+  to a spring and the renderer draws a yellow indicator showing the direction.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
     mimic contracting or extending structures.
   * **Particle orientation** – particles may optionally track a rotation angle.
     When enabled, an ``OrientationSpring`` can keep the line to another
-    particle aligned with this angle and the renderer draws a small yellow dot
-    for those particles.
+    particle aligned with this angle and the renderer draws a small yellow
+    line indicating the current orientation.
 
 ### Using high-drag particles
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
   * `particle.py` – a point mass implemented with Verlet integration.
   * `spring.py` – linear springs that apply Hooke's law and change colour depending on stretch/compression.
   * `bending_spring.py` – maintains an angle between three particles.
+  * `OrientationSpring` in `bending_spring.py` – keeps a particle's angle
+    aligned with a connected spring.
   * `physics.py` – contains ``PhysicsEngine`` which integrates particles each
     frame.  The engine applies gravity, spring forces, short range repulsion,
     viscous drag (with extra drag for particles tagged ``"high_drag"``) and
@@ -23,6 +25,10 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
     for extra grip.
   * **Adjustable springs** – spring rest lengths can be changed on the fly to
     mimic contracting or extending structures.
+  * **Particle orientation** – each particle tracks a rotation angle. An
+    ``OrientationSpring`` can keep the line to another particle aligned with
+    this angle and the renderer shows a small yellow dot to indicate the
+    direction.
 
 ### Using high-drag particles
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
     for extra grip.
   * **Adjustable springs** – spring rest lengths can be changed on the fly to
     mimic contracting or extending structures.
-  * **Particle orientation** – each particle tracks a rotation angle. An
-    ``OrientationSpring`` can keep the line to another particle aligned with
-    this angle and the renderer shows a small yellow dot to indicate the
-    direction.
+  * **Particle orientation** – particles may optionally track a rotation angle.
+    When enabled, an ``OrientationSpring`` can keep the line to another
+    particle aligned with this angle and the renderer draws a small yellow dot
+    for those particles.
 
 ### Using high-drag particles
 
@@ -72,6 +72,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **V/B** – decrease/increase particle radius
 * **K/L** – decrease/increase spring stiffness
 * **N/M** – decrease/increase simulation temperature
+* **O** – toggle orientation for newly created particles
 * **P** – pause or resume the physics update
 
 Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. The sidebar fields let you set the arm's mass, radius, stiffness, cycle speed, colours and adhesion factor before creation, and any number of arms may share the same cycle key. The **Inspect** tool can select a particle or a spring so their properties (colour, mass, radius, rest length, stiffness, **max force** and visibility) may be edited in place.  A value of ``0`` for max force disables the limit. Use the Particle, Spring or Env buttons to reveal their respective sliders.

--- a/bending_spring.py
+++ b/bending_spring.py
@@ -58,33 +58,36 @@ class BendingSpring:
         self.p3.apply_force(f3)
         self.p2.apply_force(f2)
 
-    # def apply(self):
-    #     v1 = self.p1.pos - self.p2.pos
-    #     v2 = self.p3.pos - self.p2.pos
-    #     L1, L2 = v1.length(), v2.length()
-    #     if L1 == 0 or L2 == 0:
-    #         return
-    #
-    #     # signed angle between v1 and v2
-    #     cross_z = v1.x*v2.y - v1.y*v2.x
-    #     dot     = max(-1.0, min(1.0, v1.dot(v2)/(L1*L2)))
-    #     signed_theta = math.atan2(cross_z, dot)
-    #
-    #     # deviation from rest
-    #     d_theta = signed_theta - self.rest_angle
-    #     if abs(d_theta) < 1e-6:
-    #         return
-    #
-    #     # torque → forces
-    #     torque = -self.stiffness * d_theta
-    #     u1, u2 = v1 / L1, v2 / L2
-    #     # perpendicular normals
-    #     n1 = pygame.Vector2(-u1.y, u1.x)
-    #     n2 = pygame.Vector2(u2.y, -u2.x)
-    #     f1 = n1 * torque
-    #     f3 = n2 * torque
-    #     f2 = -(f1 + f3)
-    #
-    #     self.p1.apply_force(f1)
-    #     self.p3.apply_force(f3)
-    #     self.p2.apply_force(f2)
+
+class OrientationSpring:
+    """Constrains the orientation of ``particle`` relative to ``anchor``.
+
+    The spring attempts to keep the line from ``anchor`` to ``particle`` at
+    ``rest_angle`` relative to the anchor's current ``angle`` value.  A torque
+    is applied to the anchor while a linear force rotates ``particle`` around
+    ``anchor``.
+    """
+
+    def __init__(self, anchor: Particle, particle: Particle, rest_angle: float,
+                 stiffness: float):
+        self.anchor = anchor
+        self.particle = particle
+        self.rest_angle = rest_angle
+        self.stiffness = stiffness
+
+    def apply(self):
+        delta = self.particle.pos - self.anchor.pos
+        dist = delta.length()
+        if dist == 0:
+            return
+        current_angle = math.atan2(delta.y, delta.x)
+        target_angle = getattr(self.anchor, "angle", 0.0) + self.rest_angle
+        diff = (current_angle - target_angle + math.pi) % (2 * math.pi) - math.pi
+        if abs(diff) < 1e-6:
+            return
+        torque = -self.stiffness * diff
+        dir_vec = delta / dist
+        perp = pygame.Vector2(-dir_vec.y, dir_vec.x)
+        force = perp * torque
+        self.particle.apply_force(force)
+        self.anchor.apply_torque(-torque)

--- a/bending_spring.py
+++ b/bending_spring.py
@@ -76,6 +76,8 @@ class OrientationSpring:
         self.stiffness = stiffness
 
     def apply(self):
+        if not getattr(self.anchor, "orientation_enabled", False):
+            return
         delta = self.particle.pos - self.anchor.pos
         dist = delta.length()
         if dist == 0:

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -231,7 +231,8 @@ class ParticleTool:
         self.radius_field = SliderField(
             "Radius", 1, 50, lambda: self.app.radius, self.app.set_radius, x, y, width
         )
-
+        y += 40
+        self.orient_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
     # ---------------- control
     def start(self):
         self.active = True
@@ -246,6 +247,11 @@ class ParticleTool:
         self.color_field.draw(self.sidebar.screen)
         self.mass_field.draw(self.sidebar.screen)
         self.radius_field.draw(self.sidebar.screen)
+        pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.orient_rect)
+        txt = "Orient: On" if self.app.orientation_enabled else "Orient: Off"
+        img = self.sidebar.font.render(txt, True, (255, 255, 255))
+        rect = img.get_rect(center=self.orient_rect.center)
+        self.sidebar.screen.blit(img, rect)
 
     def draw_preview(self):
         pass
@@ -260,6 +266,9 @@ class ParticleTool:
             if self.mass_field.handle_event(event):
                 return True
             if self.radius_field.handle_event(event):
+                return True
+            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1 and self.orient_rect.collidepoint(event.pos):
+                self.app.toggle_orientation()
                 return True
         return False
 
@@ -929,6 +938,8 @@ class InspectTool:
             "P Radius", 1, 50, lambda: self._get_radius(), self._set_radius, x, y, width
         )
         y += 40
+        self.orient_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
+        y += 40
         self.rest_field = SliderField(
             "S Rest", 1, 400, lambda: self._get_rest(), self._set_rest, x, y, width
         )
@@ -988,6 +999,10 @@ class InspectTool:
         if self.spring:
             self.spring.max_force = None if value == 0 else value
 
+    def _toggle_orientation(self):
+        if self.particle:
+            self.particle.orientation_enabled = not self.particle.orientation_enabled
+
     def _toggle_invisible(self):
         if self.spring:
             self.spring.invisible = not self.spring.invisible
@@ -1011,6 +1026,11 @@ class InspectTool:
             self.color_field.draw(self.sidebar.screen)
             self.mass_field.draw(self.sidebar.screen)
             self.radius_field.draw(self.sidebar.screen)
+            pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.orient_rect)
+            txt = "Orient: On" if self.particle.orientation_enabled else "Orient: Off"
+            img = self.sidebar.font.render(txt, True, (255, 255, 255))
+            rect = img.get_rect(center=self.orient_rect.center)
+            self.sidebar.screen.blit(img, rect)
         elif self.spring:
             self.rest_field.draw(self.sidebar.screen)
             self.stiff_field.draw(self.sidebar.screen)
@@ -1053,6 +1073,9 @@ class InspectTool:
                 if self.mass_field.handle_event(event):
                     return True
                 if self.radius_field.handle_event(event):
+                    return True
+                if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1 and self.orient_rect.collidepoint(event.pos):
+                    self._toggle_orientation()
                     return True
             elif self.spring:
                 if self.rest_field.handle_event(event):

--- a/hook_arm.py
+++ b/hook_arm.py
@@ -28,6 +28,7 @@ class HookArm:
         mass: float = 0.5,
         radius: float = 8,
         cycle_speed: float = 240.0,
+        orientation_enabled: bool = False,
     ):
         """Create the arm anchored at ``base`` and pointing along ``direction``.
 
@@ -62,12 +63,20 @@ class HookArm:
         self.high_drag_color = high_drag_color
         self.adhesion_mass_factor = adhesion_mass_factor
         self.cycle_speed = cycle_speed
+        self.orientation_enabled = orientation_enabled
 
         direction = direction.normalize()
         prev = base
         for i in range(1, segments + 1):
             pos = base.pos + direction * spacing * i
-            p = Particle(pos, mass=mass, radius=radius, color=color, tag="arm")
+            p = Particle(
+                pos,
+                mass=mass,
+                radius=radius,
+                color=color,
+                tag="arm",
+                orientation_enabled=self.orientation_enabled,
+            )
             self.particles.append(p)
             s = Spring(prev, p, rest_length=spacing, stiffness=stiffness)
             self.springs.append(s)

--- a/particle.py
+++ b/particle.py
@@ -4,14 +4,24 @@ import pygame
 class Particle:
     """Point mass used in the Verlet based physics simulation.
 
-    ``Particle`` now tracks an orientation angle in addition to its
-    translational state so that angular constraints can be implemented.
-    The angle is measured in radians and integrated using the same
-    Verlet style as the position variables.
+    ``Particle`` can optionally track an orientation angle so that
+    rotational constraints may be applied.  When ``orientation_enabled``
+    is ``False`` the angular state is ignored and no torque is
+    integrated.  The angle is measured in radians and, if enabled, is
+    integrated using the same Verlet style as the positional variables.
     """
 
-    def __init__(self, position, mass=1.0, color=None, radius=None, tag=None,
-                 angle: float = 0.0):
+    def __init__(
+        self,
+        position,
+        mass=1.0,
+        color=None,
+        radius=None,
+        tag=None,
+        *,
+        angle: float = 0.0,
+        orientation_enabled: bool = False,
+    ):
         self.pos = pygame.Vector2(position)
         self.prev_pos = self.pos.copy()
         self.acc = pygame.Vector2(0, 0)
@@ -23,6 +33,7 @@ class Particle:
         self.angle = angle
         self.prev_angle = angle
         self.ang_acc = 0.0
+        self.orientation_enabled = orientation_enabled
 
     def apply_force(self, force):
         if not self.fixed:
@@ -30,7 +41,7 @@ class Particle:
 
     def apply_torque(self, torque: float):
         """Accumulate angular acceleration from a torque value."""
-        if not self.fixed:
+        if not self.fixed and self.orientation_enabled:
             # moment of inertia is approximated by the mass
             self.ang_acc += torque / self.mass
 
@@ -44,8 +55,12 @@ class Particle:
         self.pos = new_pos
         self.acc = pygame.Vector2(0, 0)
 
-        ang_vel = (self.angle - self.prev_angle) * damping
-        new_angle = self.angle + ang_vel + self.ang_acc * dt * dt
-        self.prev_angle = self.angle
-        self.angle = new_angle
-        self.ang_acc = 0.0
+        if self.orientation_enabled:
+            ang_vel = (self.angle - self.prev_angle) * damping
+            new_angle = self.angle + ang_vel + self.ang_acc * dt * dt
+            self.prev_angle = self.angle
+            self.angle = new_angle
+            self.ang_acc = 0.0
+        else:
+            self.prev_angle = self.angle
+            self.ang_acc = 0.0

--- a/particle.py
+++ b/particle.py
@@ -2,9 +2,16 @@
 import pygame
 
 class Particle:
-    """Point mass used in the Verlet based physics simulation."""
+    """Point mass used in the Verlet based physics simulation.
 
-    def __init__(self, position, mass=1.0, color=None, radius=None, tag=None):
+    ``Particle`` now tracks an orientation angle in addition to its
+    translational state so that angular constraints can be implemented.
+    The angle is measured in radians and integrated using the same
+    Verlet style as the position variables.
+    """
+
+    def __init__(self, position, mass=1.0, color=None, radius=None, tag=None,
+                 angle: float = 0.0):
         self.pos = pygame.Vector2(position)
         self.prev_pos = self.pos.copy()
         self.acc = pygame.Vector2(0, 0)
@@ -13,10 +20,19 @@ class Particle:
         self.color = color
         self.radius = radius
         self.tag = tag
+        self.angle = angle
+        self.prev_angle = angle
+        self.ang_acc = 0.0
 
     def apply_force(self, force):
         if not self.fixed:
             self.acc += force / self.mass
+
+    def apply_torque(self, torque: float):
+        """Accumulate angular acceleration from a torque value."""
+        if not self.fixed:
+            # moment of inertia is approximated by the mass
+            self.ang_acc += torque / self.mass
 
     def integrate(self, dt, damping=0.98):
         if self.fixed:
@@ -27,3 +43,9 @@ class Particle:
         self.prev_pos = self.pos.copy()
         self.pos = new_pos
         self.acc = pygame.Vector2(0, 0)
+
+        ang_vel = (self.angle - self.prev_angle) * damping
+        new_angle = self.angle + ang_vel + self.ang_acc * dt * dt
+        self.prev_angle = self.angle
+        self.angle = new_angle
+        self.ang_acc = 0.0

--- a/physics.py
+++ b/physics.py
@@ -11,7 +11,7 @@ system forward in time.
 import pygame
 from particle import Particle
 from spring import Spring
-from bending_spring import BendingSpring
+from bending_spring import BendingSpring, OrientationSpring
 import random
 import math
 
@@ -26,7 +26,10 @@ class PhysicsEngine:
         Linear springs connecting pairs of particles.
     bending_springs:
         Optional list of :class:`BendingSpring` instances providing angular
-        constraints.
+        constraints between triples of particles.
+    orientation_springs:
+        Optional list of :class:`OrientationSpring` objects that tie a
+        particle's ``angle`` to the direction of one of its springs.
     gravity:
         Constant acceleration applied to each particle (x, y).
     repulsion_radius:
@@ -38,11 +41,12 @@ class PhysicsEngine:
     damping_coeff:
         Coefficient for viscous drag and the Brownian noise variance.
     """
-    def __init__(self, particles: list[Particle], springs: list[Spring], bending_springs: list[BendingSpring]=None, gravity=(0, 0), repulsion_radius=20,
+    def __init__(self, particles: list[Particle], springs: list[Spring], bending_springs: list[BendingSpring]=None, orientation_springs: list[OrientationSpring]=None, gravity=(0, 0), repulsion_radius=20,
                  repulsion_strength=100, temperature=1.0, damping_coeff=1.0):
         self.particles = particles
         self.springs = springs
         self.bending_springs = bending_springs
+        self.orientation_springs = orientation_springs
         self.gravity = pygame.Vector2(gravity)
         self.repulsion_radius = repulsion_radius
         self.repulsion_strength = repulsion_strength
@@ -71,6 +75,10 @@ class PhysicsEngine:
         if self.bending_springs:
             for bs in self.bending_springs:
                 bs.apply()
+
+        if self.orientation_springs:
+            for os in self.orientation_springs:
+                os.apply()
 
         # apply repulsion forces between particles to prevent overlap
         for i, p1 in enumerate(self.particles):

--- a/renderer.py
+++ b/renderer.py
@@ -1,5 +1,6 @@
 # renderer.py
 import pygame
+import math
 
 class Renderer:
     def __init__(self, screen: pygame.Surface):
@@ -27,6 +28,17 @@ class Renderer:
             color = p.color if p.color else (0, 0, 255)
             radius = p.radius if p.radius else 10
             pygame.draw.circle(self.screen, color, (int(p.pos.x), int(p.pos.y)), radius=radius)
+            # orientation indicator: a small dot showing the particle's angle
+            end = pygame.Vector2(
+                math.cos(getattr(p, "angle", 0.0)),
+                math.sin(getattr(p, "angle", 0.0)),
+            ) * (radius * 0.5)
+            pygame.draw.circle(
+                self.screen,
+                (255, 255, 0),
+                (int(p.pos.x + end.x), int(p.pos.y + end.y)),
+                3,
+            )
             if getattr(p, "tag", "") == "high_drag":
                 pygame.draw.circle(
                     self.screen,

--- a/renderer.py
+++ b/renderer.py
@@ -28,17 +28,18 @@ class Renderer:
             color = p.color if p.color else (0, 0, 255)
             radius = p.radius if p.radius else 10
             pygame.draw.circle(self.screen, color, (int(p.pos.x), int(p.pos.y)), radius=radius)
-            # orientation indicator: a small dot showing the particle's angle
-            end = pygame.Vector2(
-                math.cos(getattr(p, "angle", 0.0)),
-                math.sin(getattr(p, "angle", 0.0)),
-            ) * (radius * 0.5)
-            pygame.draw.circle(
-                self.screen,
-                (255, 255, 0),
-                (int(p.pos.x + end.x), int(p.pos.y + end.y)),
-                3,
-            )
+            if getattr(p, "orientation_enabled", False):
+                # orientation indicator: a small dot showing the particle's angle
+                end = pygame.Vector2(
+                    math.cos(getattr(p, "angle", 0.0)),
+                    math.sin(getattr(p, "angle", 0.0)),
+                ) * (radius * 0.5)
+                pygame.draw.circle(
+                    self.screen,
+                    (255, 255, 0),
+                    (int(p.pos.x + end.x), int(p.pos.y + end.y)),
+                    3,
+                )
             if getattr(p, "tag", "") == "high_drag":
                 pygame.draw.circle(
                     self.screen,

--- a/renderer.py
+++ b/renderer.py
@@ -29,16 +29,17 @@ class Renderer:
             radius = p.radius if p.radius else 10
             pygame.draw.circle(self.screen, color, (int(p.pos.x), int(p.pos.y)), radius=radius)
             if getattr(p, "orientation_enabled", False):
-                # orientation indicator: a small dot showing the particle's angle
+                # orientation indicator: small yellow line at the particle's angle
                 end = pygame.Vector2(
                     math.cos(getattr(p, "angle", 0.0)),
                     math.sin(getattr(p, "angle", 0.0)),
-                ) * (radius * 0.5)
-                pygame.draw.circle(
+                ) * (radius * 1.2)
+                pygame.draw.line(
                     self.screen,
                     (255, 255, 0),
+                    (int(p.pos.x), int(p.pos.y)),
                     (int(p.pos.x + end.x), int(p.pos.y + end.y)),
-                    3,
+                    2,
                 )
             if getattr(p, "tag", "") == "high_drag":
                 pygame.draw.circle(

--- a/start_create.py
+++ b/start_create.py
@@ -34,6 +34,7 @@ class BuilderApp:
         self.radius = 10
         self.color = (255, 0, 0)
         self.stiffness = 200.0
+        self.orientation_enabled = False
 
         self.font = pygame.font.SysFont(None, 24)
         self.physics = PhysicsEngine(
@@ -131,6 +132,10 @@ class BuilderApp:
     def set_stiffness(self, value: float):
         self.stiffness = max(10, value)
 
+    def toggle_orientation(self):
+        """Enable or disable orientation for newly created particles."""
+        self.orientation_enabled = not self.orientation_enabled
+
     def adjust_temperature(self, delta: float):
         self.physics.temperature = max(0, self.physics.temperature + delta)
 
@@ -147,7 +152,13 @@ class BuilderApp:
         for i in range(segments):
             theta = (i / segments) * 2 * math.pi
             pos = center + pygame.Vector2(math.cos(theta), math.sin(theta)) * radius
-            p = Particle(pos, mass=self.mass, color=self.color, radius=self.radius)
+            p = Particle(
+                pos,
+                mass=self.mass,
+                color=self.color,
+                radius=self.radius,
+                orientation_enabled=self.orientation_enabled,
+            )
             particles.append(p)
         for i in range(segments):
             p1 = particles[i]
@@ -185,6 +196,7 @@ class BuilderApp:
             mass=mass,
             radius=radius,
             cycle_speed=cycle_speed,
+            orientation_enabled=self.orientation_enabled,
         )
         arm.cycle_key = cycle_key
         if cycle_key is not None:
@@ -221,6 +233,7 @@ class BuilderApp:
             p.mass = self.mass
             p.radius = self.radius
             p.color = self.color
+            p.orientation_enabled = self.orientation_enabled
         self.particles.extend(particles)
         self.springs.extend(springs)
 
@@ -272,6 +285,8 @@ class BuilderApp:
                         self.adjust_temperature(-10)
                     elif e.key == pygame.K_m:
                         self.adjust_temperature(10)
+                    elif e.key == pygame.K_o:
+                        self.toggle_orientation()
                     elif e.key == pygame.K_p:
                         self.toggle_pause()
                     elif e.key == pygame.K_ESCAPE:
@@ -296,7 +311,13 @@ class BuilderApp:
                             )
                             self.selected.fixed = True
                     elif self.mode == "particle":
-                        p = Particle(mouse, mass=self.mass, color=self.color, radius=self.radius)
+                        p = Particle(
+                            mouse,
+                            mass=self.mass,
+                            color=self.color,
+                            radius=self.radius,
+                            orientation_enabled=self.orientation_enabled,
+                        )
                         self.particles.append(p)
                     elif self.mode == "spring":
                         if self.particles:


### PR DESCRIPTION
## Summary
- track an angle on each particle with `apply_torque` and rotational integration
- draw a yellow orientation dot per particle
- add `OrientationSpring` to keep a particle aligned with its neighbour
- allow `PhysicsEngine` to use orientation springs
- document the new feature in README and AGENTS

## Testing
- `python start_basic.py` *(fails: ModuleNotFoundError: No module named 'pygame')*
- `pip install pygame` *(fails: Could not find a version that satisfies the requirement pygame)*

------
https://chatgpt.com/codex/tasks/task_e_688a74c857bc832591c58dcfda9aeb38