### PR TITLE
Add hinge demo and orientation rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This repository contains small pygame demos for 2D particle-based physics simula
 - `particle.py` – Particle class using Verlet integration.
 - `spring.py` – linear spring connecting two particles.
 - `bending_spring.py` – bending constraint that keeps an angle between three particles.
+- `hinge.py` – constrains a spring's direction relative to a particle's orientation.
 - `physics.py` – `PhysicsEngine` that applies forces, drag and Brownian noise.
 - `renderer.py` – draws particles and springs to the screen.
 - `structures.py` – helper routines for building walls, rods and other shapes.
@@ -20,6 +21,7 @@ This repository contains small pygame demos for 2D particle-based physics simula
 - `start_hook_arm.py` – cell with a flexible hook arm.
 - `start_four_rods.py` – four rod structures positioned around the centre.
 - `start_gradient_wall.py` – four rods coloured with a gradient.
+- `start_hinge_demo.py` – rotating hinge demonstration.
 
 ## Maintaining the project
 
@@ -50,3 +52,7 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - Particle colour/mass/radius sliders and the spring stiffness slider only appear when their creation modes are active.
 - Particle, spring and environment controls now live behind separate sidebar buttons.
 - Hook arm creation now has a cycle speed slider controlling how fast the arm extends and retracts.
+- Particles may carry an orientation angle; ``hinge.py`` applies forces keeping
+  attached springs aligned with it.
+- Renderer draws a white arrow on particles that specify an orientation and
+  ``start_hinge_demo.py`` demonstrates the hinge behaviour.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
     for extra grip.
   * **Adjustable springs** – spring rest lengths can be changed on the fly to
     mimic contracting or extending structures.
+  * **Hinge springs** – particles may define an orientation and springs can be
+    constrained to maintain a fixed angle relative to it. Particles with an
+    orientation are drawn with a small arrow showing the direction.
+    Pass an ``orientation`` angle when creating a ``Particle`` and add
+    ``HingeSpring`` instances to the physics engine to activate the behaviour.
 
 ### Using high-drag particles
 
@@ -96,6 +101,9 @@ keyboard shortcuts:
   same controls as `start.py`.
 * **`start_gradient_wall.py`** – similar to `start_four_rods.py` but colours each
   rod with a gradient.
+* **`start_hinge_demo.py`** – shows a simple hinge. The base particle's
+  orientation rotates and a hinge constraint keeps the attached particle
+  aligned with the arrow.
 
 Feel free to modify any of these scripts or build new configurations using the interactive builder.
 

--- a/hinge.py
+++ b/hinge.py
@@ -1,0 +1,45 @@
+# hinge.py
+"""Orientation constraint for particles acting like rigid hinges.
+
+This module defines :class:`HingeSpring` which keeps the angle between
+an oriented particle and another particle constant.  The hinge does not
+have its own rotational inertia; instead equal and opposite forces are
+applied to the two connected particles.
+"""
+
+import math
+import pygame
+from particle import Particle
+
+
+class HingeSpring:
+    """Constrain the angle between two particles around a hinge."""
+
+    def __init__(self, base: Particle, other: Particle, rest_angle: float, stiffness: float):
+        self.base = base
+        self.other = other
+        self.rest_angle = rest_angle
+        self.stiffness = stiffness
+
+    def apply(self):
+        if self.base.orientation is None:
+            return
+        v = self.other.pos - self.base.pos
+        length = v.length()
+        if length == 0:
+            return
+        dir_v = v / length
+        target = pygame.Vector2(
+            math.cos(self.base.orientation + self.rest_angle),
+            math.sin(self.base.orientation + self.rest_angle),
+        )
+        dot = max(-1.0, min(1.0, target.dot(dir_v)))
+        cross_z = target.x * dir_v.y - target.y * dir_v.x
+        d_theta = math.atan2(cross_z, dot)
+        if abs(d_theta) < 1e-6:
+            return
+        torque = -self.stiffness * d_theta
+        normal = pygame.Vector2(-dir_v.y, dir_v.x)
+        force = normal * torque
+        self.other.apply_force(force)
+        self.base.apply_force(-force)

--- a/particle.py
+++ b/particle.py
@@ -2,9 +2,26 @@
 import pygame
 
 class Particle:
-    """Point mass used in the Verlet based physics simulation."""
+    """Point mass used in the Verlet based physics simulation.
 
-    def __init__(self, position, mass=1.0, color=None, radius=None, tag=None):
+    Parameters
+    ----------
+    position:
+        Initial ``(x, y)`` coordinates.
+    mass:
+        Scalar mass value.
+    color:
+        Optional RGB tuple used when rendering.
+    radius:
+        Particle radius in pixels for drawing.
+    tag:
+        Arbitrary string label.
+    orientation:
+        Optional angle in radians for hinge particles.  ``None`` means the
+        particle has no preferred orientation.
+    """
+
+    def __init__(self, position, mass=1.0, color=None, radius=None, tag=None, orientation=None):
         self.pos = pygame.Vector2(position)
         self.prev_pos = self.pos.copy()
         self.acc = pygame.Vector2(0, 0)
@@ -13,6 +30,7 @@ class Particle:
         self.color = color
         self.radius = radius
         self.tag = tag
+        self.orientation = orientation
 
     def apply_force(self, force):
         if not self.fixed:

--- a/physics.py
+++ b/physics.py
@@ -12,6 +12,7 @@ import pygame
 from particle import Particle
 from spring import Spring
 from bending_spring import BendingSpring
+from hinge import HingeSpring
 import random
 import math
 
@@ -27,6 +28,9 @@ class PhysicsEngine:
     bending_springs:
         Optional list of :class:`BendingSpring` instances providing angular
         constraints.
+    hinge_springs:
+        Optional list of :class:`HingeSpring` constraints which tie spring
+        directions to a particle's orientation.
     gravity:
         Constant acceleration applied to each particle (x, y).
     repulsion_radius:
@@ -38,11 +42,13 @@ class PhysicsEngine:
     damping_coeff:
         Coefficient for viscous drag and the Brownian noise variance.
     """
-    def __init__(self, particles: list[Particle], springs: list[Spring], bending_springs: list[BendingSpring]=None, gravity=(0, 0), repulsion_radius=20,
+    def __init__(self, particles: list[Particle], springs: list[Spring], bending_springs: list[BendingSpring]=None,
+                 hinge_springs: list[HingeSpring]=None, gravity=(0, 0), repulsion_radius=20,
                  repulsion_strength=100, temperature=1.0, damping_coeff=1.0):
         self.particles = particles
         self.springs = springs
         self.bending_springs = bending_springs
+        self.hinge_springs = hinge_springs
         self.gravity = pygame.Vector2(gravity)
         self.repulsion_radius = repulsion_radius
         self.repulsion_strength = repulsion_strength
@@ -71,6 +77,10 @@ class PhysicsEngine:
         if self.bending_springs:
             for bs in self.bending_springs:
                 bs.apply()
+
+        if self.hinge_springs:
+            for hs in self.hinge_springs:
+                hs.apply()
 
         # apply repulsion forces between particles to prevent overlap
         for i, p1 in enumerate(self.particles):

--- a/renderer.py
+++ b/renderer.py
@@ -1,5 +1,6 @@
 # renderer.py
 import pygame
+import math
 
 class Renderer:
     def __init__(self, screen: pygame.Surface):
@@ -34,4 +35,30 @@ class Renderer:
                     (int(p.pos.x), int(p.pos.y)),
                     radius + 4,
                     width=2,
+                )
+
+            if getattr(p, "orientation", None) is not None:
+                angle = p.orientation
+                arrow_len = radius + 15
+                end = pygame.Vector2(
+                    p.pos.x + arrow_len * math.cos(angle),
+                    p.pos.y + arrow_len * math.sin(angle),
+                )
+                pygame.draw.line(
+                    self.screen, (255, 255, 255), p.pos, end, width=2
+                )
+                head_len = 6
+                head_angle = math.radians(20)
+                left = end + pygame.Vector2(
+                    -head_len * math.cos(angle - head_angle),
+                    -head_len * math.sin(angle - head_angle),
+                )
+                right = end + pygame.Vector2(
+                    -head_len * math.cos(angle + head_angle),
+                    -head_len * math.sin(angle + head_angle),
+                )
+                pygame.draw.polygon(
+                    self.screen,
+                    (255, 255, 255),
+                    [end, left, right]
                 )

--- a/start_hinge_demo.py
+++ b/start_hinge_demo.py
@@ -1,0 +1,65 @@
+"""Simple demo showcasing particles with hinge orientation.
+
+A central particle holds an orientation arrow. A second particle is attached
+with a spring and hinge constraint. The base orientation slowly rotates so the
+other particle moves around like connected by a rigid hinge.
+"""
+
+import pygame
+from particle import Particle
+from spring import Spring
+from hinge import HingeSpring
+from physics import PhysicsEngine
+from renderer import Renderer
+
+SCREEN_SIZE = (800, 600)
+FPS = 60
+
+
+class HingeApp:
+    """Rotate the base orientation to demonstrate hinge behaviour."""
+
+    def __init__(self):
+        pygame.init()
+        self.screen = pygame.display.set_mode(SCREEN_SIZE)
+        self.clock = pygame.time.Clock()
+        self.particles = []
+        self.springs = []
+        self.hinges = []
+        self._create_setup()
+        self.engine = PhysicsEngine(
+            self.particles, self.springs, hinge_springs=self.hinges, gravity=(0, 0)
+        )
+        self.renderer = Renderer(self.screen)
+
+    def _create_setup(self):
+        center = pygame.Vector2(SCREEN_SIZE) / 2
+        base = Particle(center, radius=12, color=(0, 200, 255), orientation=0)
+        tip_pos = center + pygame.Vector2(100, 0)
+        tip = Particle(tip_pos, radius=8, color=(255, 200, 0))
+        self.particles.extend([base, tip])
+        rest = (tip.pos - base.pos).length()
+        self.springs.append(Spring(base, tip, rest, stiffness=200))
+        self.hinges.append(HingeSpring(base, tip, rest_angle=0, stiffness=2))
+        self.base = base
+
+    def run(self):
+        running = True
+        while running:
+            dt = self.clock.tick(FPS) / 1000
+            for e in pygame.event.get():
+                if e.type == pygame.QUIT:
+                    running = False
+
+            # slowly rotate the base orientation
+            self.base.orientation += dt
+            self.engine.update(dt)
+            self.screen.fill((30, 30, 30))
+            self.renderer.draw(self.particles, self.springs)
+            pygame.display.flip()
+
+        pygame.quit()
+
+
+if __name__ == "__main__":
+    HingeApp().run()


### PR DESCRIPTION
## Summary
- draw a white arrow for particles that define an `orientation`
- document hinge orientation rendering and new start script
- add `start_hinge_demo.py` showcasing hinge behaviour

## Testing
- `python start_hinge_demo.py` *(fails: ModuleNotFoundError: No module named 'pygame')*


------
https://chatgpt.com/codex/tasks/task_e_688a821b780483259c7cf44b35eceb0a