### PR TITLE
Add more env sliders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,4 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - Particle colour/mass/radius sliders and the spring stiffness slider only appear when their creation modes are active.
 - Particle, spring and environment controls now live behind separate sidebar buttons.
 - Hook arm creation now has a cycle speed slider controlling how fast the arm extends and retracts.
+- The environment tool exposes sliders for gravity, repulsion and damping in addition to temperature.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 
 ## Features
 
-* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and temperature. Tools exist for circles, rods, flexible hook arms and an inspect mode for tweaking existing particles and springs.  Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle, spring and environment controls each have their own button in the sidebar.
+* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and various environment settings like temperature, gravity, repulsion and damping. Tools exist for circles, rods, flexible hook arms and an inspect mode for tweaking existing particles and springs.  Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle, spring and environment controls each have their own button in the sidebar.
 * **Demo scenes** – other `start_*.py` files showcase different preset configurations (e.g. cell walls, rods or gradient walls).  They are good starting points for custom experiments.
 * **Modular codebase** – the core simulation is split into small modules:
   * `particle.py` – a point mass implemented with Verlet integration.
@@ -60,7 +60,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **5** – create rod structures
 * **6** – attach a hook arm to a particle
 * **7** – inspect an existing particle or spring
-* **8** – adjust environment settings (temperature)
+* **8** – adjust environment settings (temperature, gravity, repulsion and damping)
 * **C** – choose a colour for newly created particles
 * **Z/X** – decrease/increase particle mass
 * **V/B** – decrease/increase particle radius

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -307,7 +307,7 @@ class SpringTool:
 
 
 class EnvironmentTool:
-    """Expose global simulation options such as temperature."""
+    """Expose global simulation options such as gravity and temperature."""
 
     def __init__(self, sidebar: 'SidebarUI'):
         self.sidebar = sidebar
@@ -318,8 +318,46 @@ class EnvironmentTool:
         width = sidebar.WIDTH - 20
         y = sidebar.extra_start_y
 
+        self.gx_field = SliderField(
+            "Grav X", -2000, 2000,
+            lambda: self.app.physics.gravity.x,
+            self.app.set_gravity_x,
+            x, y, width,
+        )
+        y += 40
+        self.gy_field = SliderField(
+            "Grav Y", -2000, 2000,
+            lambda: self.app.physics.gravity.y,
+            self.app.set_gravity_y,
+            x, y, width,
+        )
+        y += 40
+        self.rep_rad_field = SliderField(
+            "Rep Rad", 0, 200,
+            lambda: self.app.physics.repulsion_radius,
+            self.app.set_repulsion_radius,
+            x, y, width,
+        )
+        y += 40
+        self.rep_str_field = SliderField(
+            "Rep Str", 0, 10000,
+            lambda: self.app.physics.repulsion_strength,
+            self.app.set_repulsion_strength,
+            x, y, width,
+        )
+        y += 40
+        self.damp_field = SliderField(
+            "Damp", 0, 5,
+            lambda: self.app.physics.damping_coeff,
+            self.app.set_damping,
+            x, y, width,
+        )
+        y += 40
         self.temp_field = SliderField(
-            "Temp", 0, 1000, lambda: self.app.physics.temperature, self.app.set_temperature, x, y, width
+            "Temp", 0, 1000,
+            lambda: self.app.physics.temperature,
+            self.app.set_temperature,
+            x, y, width,
         )
 
     # ---------------- control
@@ -333,6 +371,11 @@ class EnvironmentTool:
     def draw_ui(self):
         if not self.active or not self.sidebar.visible:
             return
+        self.gx_field.draw(self.sidebar.screen)
+        self.gy_field.draw(self.sidebar.screen)
+        self.rep_rad_field.draw(self.sidebar.screen)
+        self.rep_str_field.draw(self.sidebar.screen)
+        self.damp_field.draw(self.sidebar.screen)
         self.temp_field.draw(self.sidebar.screen)
 
     def draw_preview(self):
@@ -343,6 +386,16 @@ class EnvironmentTool:
         if not self.active:
             return False
         if self.sidebar.visible:
+            if self.gx_field.handle_event(event):
+                return True
+            if self.gy_field.handle_event(event):
+                return True
+            if self.rep_rad_field.handle_event(event):
+                return True
+            if self.rep_str_field.handle_event(event):
+                return True
+            if self.damp_field.handle_event(event):
+                return True
             if self.temp_field.handle_event(event):
                 return True
         return False

--- a/start_create.py
+++ b/start_create.py
@@ -137,6 +137,26 @@ class BuilderApp:
     def set_temperature(self, value: float):
         self.physics.temperature = max(0, value)
 
+    def set_gravity_x(self, value: float):
+        """Update the X component of global gravity."""
+        self.physics.gravity.x = value
+
+    def set_gravity_y(self, value: float):
+        """Update the Y component of global gravity."""
+        self.physics.gravity.y = value
+
+    def set_repulsion_radius(self, value: float):
+        """Set the particle repulsion radius."""
+        self.physics.repulsion_radius = max(0, value)
+
+    def set_repulsion_strength(self, value: float):
+        """Set the magnitude of the short range repulsive force."""
+        self.physics.repulsion_strength = max(0, value)
+
+    def set_damping(self, value: float):
+        """Adjust the damping coefficient used for drag forces."""
+        self.physics.damping_coeff = max(0, value)
+
     def toggle_pause(self):
         self.paused = not self.paused
 


### PR DESCRIPTION
## Summary
- allow adjusting gravity, repulsion and damping via the Env tool
- expose helper setters in `BuilderApp`
- document new environment options

## Testing
- `python start_create.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_688a8cdae7ec8325ae1318d312cccc03