### PR TITLE
Add bending spring builder tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,4 +52,6 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - Hook arm creation now has a cycle speed slider controlling how fast the arm extends and retracts.
 - The environment tool exposes sliders for gravity, repulsion and damping in addition to temperature.
 - Bending springs can now be created in the builder by selecting three particles.
-  They render as yellow hinges and their rest angle and stiffness are editable.
+  They render as yellow dashed hinges and their rest angle and stiffness are editable.
+- A toggle lets bending springs use the current angle of the selected particles
+  or a manual value. Inspect mode can modify their angle and stiffness later.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,5 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - Particle, spring and environment controls now live behind separate sidebar buttons.
 - Hook arm creation now has a cycle speed slider controlling how fast the arm extends and retracts.
 - The environment tool exposes sliders for gravity, repulsion and damping in addition to temperature.
+- Bending springs can now be created in the builder by selecting three particles.
+  They render as yellow hinges and their rest angle and stiffness are editable.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 
 ## Features
 
-* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and various environment settings like temperature, gravity, repulsion and damping. Tools exist for circles, rods, bending springs, flexible hook arms and an inspect mode for tweaking existing particles and springs.  Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle, spring and environment controls each have their own button in the sidebar.
+* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and various environment settings like temperature, gravity, repulsion and damping. Tools exist for circles, rods, bending springs, flexible hook arms and an inspect mode for tweaking existing particles and springs. Bending springs may use the current angle of the selected particles or a manual value. Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle, spring and environment controls each have their own button in the sidebar.
 * **Demo scenes** – other `start_*.py` files showcase different preset configurations (e.g. cell walls, rods or gradient walls).  They are good starting points for custom experiments.
 * **Modular codebase** – the core simulation is split into small modules:
   * `particle.py` – a point mass implemented with Verlet integration.
@@ -59,7 +59,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **4** – delete the particle or spring under the cursor
 * **5** – create rod structures
 * **6** – attach a hook arm to a particle
-* **7** – inspect an existing particle or spring
+* **7** – inspect an existing particle, spring or bending spring
 * **8** – adjust environment settings (temperature, gravity, repulsion and damping)
 * **9** – create a bending spring from three particles
 * **C** – choose a colour for newly created particles

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 
 ## Features
 
-* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and various environment settings like temperature, gravity, repulsion and damping. Tools exist for circles, rods, flexible hook arms and an inspect mode for tweaking existing particles and springs.  Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle, spring and environment controls each have their own button in the sidebar.
+* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and various environment settings like temperature, gravity, repulsion and damping. Tools exist for circles, rods, bending springs, flexible hook arms and an inspect mode for tweaking existing particles and springs.  Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle, spring and environment controls each have their own button in the sidebar.
 * **Demo scenes** – other `start_*.py` files showcase different preset configurations (e.g. cell walls, rods or gradient walls).  They are good starting points for custom experiments.
 * **Modular codebase** – the core simulation is split into small modules:
   * `particle.py` – a point mass implemented with Verlet integration.
@@ -61,6 +61,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **6** – attach a hook arm to a particle
 * **7** – inspect an existing particle or spring
 * **8** – adjust environment settings (temperature, gravity, repulsion and damping)
+* **9** – create a bending spring from three particles
 * **C** – choose a colour for newly created particles
 * **Z/X** – decrease/increase particle mass
 * **V/B** – decrease/increase particle radius

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -1,6 +1,7 @@
 import pygame
 import math
 from color_picker import choose_color
+from bending_spring import BendingSpring
 
 
 class SliderField:
@@ -303,6 +304,114 @@ class SpringTool:
         if self.sidebar.visible:
             if self.stiff_field.handle_event(event):
                 return True
+        return False
+
+
+class BendingSpringTool:
+    """Create a bending spring by choosing three particles."""
+
+    def __init__(self, sidebar: 'SidebarUI'):
+        self.sidebar = sidebar
+        self.app = sidebar.app
+        self.active = False
+        self.angle = 90.0
+        self.stiffness = 200.0
+        self.selected: list = []
+
+        x = sidebar.screen.get_width() - sidebar.WIDTH + 10
+        width = sidebar.WIDTH - 20
+        y = sidebar.extra_start_y
+
+        self.angle_field = SliderField(
+            "Angle", 0, 180, lambda: self.angle, self._set_angle, x, y, width
+        )
+        y += 40
+        self.stiff_field = SliderField(
+            "Stiff", 10, 1000, lambda: self.stiffness, self._set_stiff, x, y, width
+        )
+        y += 40
+        self.create_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
+
+    def _set_angle(self, val: float):
+        self.angle = max(0, val)
+
+    def _set_stiff(self, val: float):
+        self.stiffness = max(10, val)
+
+    # ---------------- control
+    def start(self):
+        self.active = True
+        self.selected.clear()
+
+    def cancel(self):
+        self.active = False
+        self.selected.clear()
+
+    # ---------------- drawing
+    def draw_ui(self):
+        if not self.active or not self.sidebar.visible:
+            return
+        self.angle_field.draw(self.sidebar.screen)
+        self.stiff_field.draw(self.sidebar.screen)
+        pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.create_rect)
+        txt = self.sidebar.font.render("Create", True, (255, 255, 255))
+        rect = txt.get_rect(center=self.create_rect.center)
+        self.sidebar.screen.blit(txt, rect)
+
+    def draw_preview(self):
+        if not self.active:
+            return
+        screen = self.sidebar.screen
+        color = (150, 150, 150)
+        for p in self.selected:
+            pygame.draw.circle(screen, color, (int(p.pos.x), int(p.pos.y)), int(p.radius) + 4, 1)
+        if len(self.selected) >= 2:
+            pygame.draw.line(screen, color, self.selected[0].pos, self.selected[1].pos, 1)
+        if len(self.selected) == 3:
+            pygame.draw.line(screen, color, self.selected[1].pos, self.selected[2].pos, 1)
+
+    # ---------------- event handling
+    def handle_event(self, event):
+        if not self.active:
+            return False
+
+        if self.sidebar.visible:
+            if self.angle_field.handle_event(event):
+                return True
+            if self.stiff_field.handle_event(event):
+                return True
+            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                if self.create_rect.collidepoint(event.pos) and len(self.selected) == 3:
+                    from math import radians
+                    bs = BendingSpring(
+                        self.selected[0],
+                        self.selected[1],
+                        self.selected[2],
+                        radians(self.angle),
+                        self.stiffness,
+                    )
+                    self.app.bending_springs.append(bs)
+                    self.cancel()
+                    self.sidebar.app.set_mode("drag")
+                    return True
+
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if event.pos[0] < self.sidebar.screen.get_width() - self.sidebar.visible_width():
+                if self.app.particles:
+                    mouse = pygame.Vector2(event.pos)
+                    particle = min(self.app.particles, key=lambda p: (p.pos - mouse).length())
+                    if particle not in self.selected:
+                        if len(self.selected) < 3:
+                            self.selected.append(particle)
+                        else:
+                            self.selected.pop(0)
+                            self.selected.append(particle)
+                    return True
+
+        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+            self.selected.clear()
+            return True
+
         return False
 
 
@@ -1172,6 +1281,7 @@ class SidebarUI:
         # setup circle tool after computing layout
         self.particle_tool = ParticleTool(self)
         self.spring_tool = SpringTool(self)
+        self.bend_tool = BendingSpringTool(self)
         self.circle_tool = CircleTool(self)
         self.rod_tool = RodTool(self)
         self.arm_tool = HookArmTool(self)
@@ -1193,6 +1303,7 @@ class SidebarUI:
         add_button("Drag", lambda: self.app.set_mode("drag"))
         add_button("Particle", lambda: self.app.set_mode("particle"))
         add_button("Spring", lambda: self.app.set_mode("spring"))
+        add_button("Bend", lambda: self.app.set_mode("bend"))
         add_button("Circle", lambda: self.app.set_mode("circle"))
         add_button("Rod", lambda: self.app.set_mode("rod"))
         add_button("Arm", lambda: self.app.set_mode("arm"))
@@ -1231,6 +1342,7 @@ class SidebarUI:
             # extra UI from tools
             self.particle_tool.draw_ui()
             self.spring_tool.draw_ui()
+            self.bend_tool.draw_ui()
             self.circle_tool.draw_ui()
             self.rod_tool.draw_ui()
             self.arm_tool.draw_ui()
@@ -1240,6 +1352,7 @@ class SidebarUI:
         # preview from tools (visible or not)
         self.particle_tool.draw_preview()
         self.spring_tool.draw_preview()
+        self.bend_tool.draw_preview()
         self.circle_tool.draw_preview()
         self.rod_tool.draw_preview()
         self.arm_tool.draw_preview()
@@ -1275,6 +1388,8 @@ class SidebarUI:
         if self.particle_tool.handle_event(event):
             return True
         if self.spring_tool.handle_event(event):
+            return True
+        if self.bend_tool.handle_event(event):
             return True
         if self.circle_tool.handle_event(event):
             return True

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -316,6 +316,7 @@ class BendingSpringTool:
         self.active = False
         self.angle = 90.0
         self.stiffness = 200.0
+        self.auto_angle = False
         self.selected: list = []
 
         x = sidebar.screen.get_width() - sidebar.WIDTH + 10
@@ -330,6 +331,8 @@ class BendingSpringTool:
             "Stiff", 10, 1000, lambda: self.stiffness, self._set_stiff, x, y, width
         )
         y += 40
+        self.auto_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
+        y += SidebarUI.BUTTON_HEIGHT + 12
         self.create_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
 
     def _set_angle(self, val: float):
@@ -341,6 +344,7 @@ class BendingSpringTool:
     # ---------------- control
     def start(self):
         self.active = True
+        self.auto_angle = False
         self.selected.clear()
 
     def cancel(self):
@@ -351,8 +355,14 @@ class BendingSpringTool:
     def draw_ui(self):
         if not self.active or not self.sidebar.visible:
             return
-        self.angle_field.draw(self.sidebar.screen)
+        if not self.auto_angle:
+            self.angle_field.draw(self.sidebar.screen)
         self.stiff_field.draw(self.sidebar.screen)
+        pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.auto_rect)
+        label = "Auto" if not self.auto_angle else "Manual"
+        txt = self.sidebar.font.render(label, True, (255, 255, 255))
+        rect = txt.get_rect(center=self.auto_rect.center)
+        self.sidebar.screen.blit(txt, rect)
         pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.create_rect)
         txt = self.sidebar.font.render("Create", True, (255, 255, 255))
         rect = txt.get_rect(center=self.create_rect.center)
@@ -376,18 +386,33 @@ class BendingSpringTool:
             return False
 
         if self.sidebar.visible:
-            if self.angle_field.handle_event(event):
-                return True
+            if not self.auto_angle:
+                if self.angle_field.handle_event(event):
+                    return True
             if self.stiff_field.handle_event(event):
                 return True
             if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                if self.auto_rect.collidepoint(event.pos):
+                    self.auto_angle = not self.auto_angle
+                    return True
+            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
                 if self.create_rect.collidepoint(event.pos) and len(self.selected) == 3:
                     from math import radians
+                    if self.auto_angle:
+                        v1 = self.selected[0].pos - self.selected[1].pos
+                        v2 = self.selected[2].pos - self.selected[1].pos
+                        if v1.length() == 0 or v2.length() == 0:
+                            angle = 0
+                        else:
+                            dot = max(-1.0, min(1.0, v1.dot(v2) / (v1.length()*v2.length())))
+                            angle = math.acos(dot)
+                    else:
+                        angle = radians(self.angle)
                     bs = BendingSpring(
                         self.selected[0],
                         self.selected[1],
                         self.selected[2],
-                        radians(self.angle),
+                        angle,
                         self.stiffness,
                     )
                     self.app.bending_springs.append(bs)
@@ -1074,6 +1099,7 @@ class InspectTool:
         self.active = False
         self.particle = None
         self.spring = None
+        self.bend = None
 
         x = sidebar.screen.get_width() - sidebar.WIDTH + 10
         width = sidebar.WIDTH - 20
@@ -1101,6 +1127,14 @@ class InspectTool:
         y += 40
         self.max_field = SliderField(
             "S MaxF", 0, 2000, lambda: self._get_max(), self._set_max, x, y, width
+        )
+        y += 40
+        self.bangle_field = SliderField(
+            "B Ang", 0, 180, lambda: self._get_bangle(), self._set_bangle, x, y, width
+        )
+        y += 40
+        self.bstiff_field = SliderField(
+            "B Stiff", 10, 1000, lambda: self._get_bstiff(), self._set_bstiff, x, y, width
         )
         y += 40
         self.invis_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
@@ -1141,6 +1175,20 @@ class InspectTool:
         if self.spring:
             self.spring.stiffness = max(10, value)
 
+    def _get_bangle(self):
+        return math.degrees(self.bend.rest_angle) if self.bend else 0
+
+    def _set_bangle(self, value: float):
+        if self.bend:
+            self.bend.rest_angle = math.radians(max(0, value))
+
+    def _get_bstiff(self):
+        return self.bend.stiffness if self.bend else 0
+
+    def _set_bstiff(self, value: float):
+        if self.bend:
+            self.bend.stiffness = max(10, value)
+
     def _get_max(self):
         if not self.spring:
             return 0
@@ -1159,11 +1207,13 @@ class InspectTool:
         self.active = True
         self.particle = None
         self.spring = None
+        self.bend = None
 
     def cancel(self):
         self.active = False
         self.particle = None
         self.spring = None
+        self.bend = None
 
     # ---------------- drawing
     def draw_ui(self):
@@ -1182,6 +1232,9 @@ class InspectTool:
             img = self.sidebar.font.render(txt, True, (255, 255, 255))
             rect = img.get_rect(center=self.invis_rect.center)
             self.sidebar.screen.blit(img, rect)
+        elif self.bend:
+            self.bangle_field.draw(self.sidebar.screen)
+            self.bstiff_field.draw(self.sidebar.screen)
 
     def draw_preview(self):
         if not self.active:
@@ -1200,6 +1253,21 @@ class InspectTool:
                 (255, 255, 0),
                 self.spring.p1.pos,
                 self.spring.p2.pos,
+                3,
+            )
+        elif self.bend:
+            pygame.draw.line(
+                self.sidebar.screen,
+                (255, 255, 0),
+                self.bend.p1.pos,
+                self.bend.p2.pos,
+                3,
+            )
+            pygame.draw.line(
+                self.sidebar.screen,
+                (255, 255, 0),
+                self.bend.p2.pos,
+                self.bend.p3.pos,
                 3,
             )
 
@@ -1226,14 +1294,21 @@ class InspectTool:
                 if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1 and self.invis_rect.collidepoint(event.pos):
                     self._toggle_invisible()
                     return True
+            elif self.bend:
+                if self.bangle_field.handle_event(event):
+                    return True
+                if self.bstiff_field.handle_event(event):
+                    return True
 
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             if event.pos[0] < self.sidebar.screen.get_width() - self.sidebar.visible_width():
                 mouse = pygame.Vector2(event.pos)
                 dist_p = float("inf")
                 dist_s = float("inf")
+                dist_b = float("inf")
                 nearest_p = None
                 nearest_s = None
+                nearest_b = None
                 if self.app.particles:
                     nearest_p = min(self.app.particles, key=lambda p: (p.pos - mouse).length())
                     dist_p = (nearest_p.pos - mouse).length()
@@ -1249,15 +1324,35 @@ class InspectTool:
                         return (mouse - proj).length()
                     nearest_s = min(self.app.springs, key=seg_dist)
                     dist_s = seg_dist(nearest_s)
-                if dist_p <= dist_s:
+                if self.app.bending_springs:
+                    def seg_dist_b(bs):
+                        def seg(a, b):
+                            d = b - a
+                            if d.length_squared() == 0:
+                                return (mouse - a).length()
+                            t = max(0, min(1, (mouse - a).dot(d) / d.length_squared()))
+                            proj = a + d * t
+                            return (mouse - proj).length()
+                        return min(seg(bs.p1.pos, bs.p2.pos), seg(bs.p2.pos, bs.p3.pos))
+                    nearest_b = min(self.app.bending_springs, key=seg_dist_b)
+                    dist_b = seg_dist_b(nearest_b)
+                if dist_p <= dist_s and dist_p <= dist_b:
                     if nearest_p is not None:
                         self.particle = nearest_p
                         self.spring = None
+                        self.bend = None
                         return True
-                else:
+                elif dist_s <= dist_b:
                     if nearest_s is not None:
                         self.spring = nearest_s
                         self.particle = None
+                        self.bend = None
+                        return True
+                else:
+                    if nearest_b is not None:
+                        self.bend = nearest_b
+                        self.particle = None
+                        self.spring = None
                         return True
 
         return False

--- a/renderer.py
+++ b/renderer.py
@@ -2,10 +2,24 @@
 import pygame
 
 class Renderer:
+    """Simple helper that draws particles, springs and bending springs."""
+
     def __init__(self, screen: pygame.Surface):
         self.screen = screen
 
-    def draw(self, particles: list, springs: list):
+    def draw(self, particles: list, springs: list, bending_springs: list | None = None):
+        """Render the simulation objects to the screen.
+
+        Parameters
+        ----------
+        particles:
+            Sequence of particles to draw.
+        springs:
+            Standard linear springs to draw.
+        bending_springs:
+            Optional list of ``BendingSpring`` objects which will be rendered as
+            two connected segments.
+        """
         # draw springs
         for s in springs:
             if getattr(s, "broken", False):
@@ -21,9 +35,15 @@ class Renderer:
                 
             pygame.draw.line(self.screen, color, s.p1.pos, s.p2.pos, 5)
 
+        # draw bending springs if provided
+        if bending_springs:
+            for bs in bending_springs:
+                color = (200, 200, 0)
+                pygame.draw.line(self.screen, color, bs.p1.pos, bs.p2.pos, 3)
+                pygame.draw.line(self.screen, color, bs.p2.pos, bs.p3.pos, 3)
+
         # draw particles
         for p in particles:
-            # color = (255, 0, 0) if p.fixed else (0, 0, 255)
             color = p.color if p.color else (0, 0, 255)
             radius = p.radius if p.radius else 10
             pygame.draw.circle(self.screen, color, (int(p.pos.x), int(p.pos.y)), radius=radius)

--- a/renderer.py
+++ b/renderer.py
@@ -7,6 +7,19 @@ class Renderer:
     def __init__(self, screen: pygame.Surface):
         self.screen = screen
 
+    def _draw_dashed_line(self, start, end, color, width=1, dash=6):
+        start = pygame.Vector2(start)
+        end = pygame.Vector2(end)
+        vec = end - start
+        length = vec.length()
+        if length == 0:
+            return
+        direction = vec.normalize()
+        for i in range(0, int(length), dash * 2):
+            s = start + direction * i
+            e = start + direction * min(i + dash, length)
+            pygame.draw.line(self.screen, color, s, e, width)
+
     def draw(self, particles: list, springs: list, bending_springs: list | None = None):
         """Render the simulation objects to the screen.
 
@@ -39,8 +52,8 @@ class Renderer:
         if bending_springs:
             for bs in bending_springs:
                 color = (200, 200, 0)
-                pygame.draw.line(self.screen, color, bs.p1.pos, bs.p2.pos, 3)
-                pygame.draw.line(self.screen, color, bs.p2.pos, bs.p3.pos, 3)
+                self._draw_dashed_line(bs.p1.pos, bs.p2.pos, color, 3)
+                self._draw_dashed_line(bs.p2.pos, bs.p3.pos, color, 3)
 
         # draw particles
         for p in particles:

--- a/start_create.py
+++ b/start_create.py
@@ -4,6 +4,7 @@ import math
 from particle import Particle
 from spring import Spring
 from physics import PhysicsEngine
+from bending_spring import BendingSpring
 from renderer import Renderer
 from builder_ui import SidebarUI
 from structures import create_rod as structure_create_rod
@@ -22,6 +23,7 @@ class BuilderApp:
         self.clock = pygame.time.Clock()
         self.particles: list[Particle] = []
         self.springs: list[Spring] = []
+        self.bending_springs: list[BendingSpring] = []
         self.arms: list[HookArm] = []
         self.cycle_keys: dict[int, list[HookArm]] = {}
         self.selected = None
@@ -39,6 +41,7 @@ class BuilderApp:
         self.physics = PhysicsEngine(
             self.particles,
             self.springs,
+            self.bending_springs,
             gravity=(0, 0),
             repulsion_radius=30,
             repulsion_strength=1000,
@@ -62,6 +65,8 @@ class BuilderApp:
             self.ui.particle_tool.cancel()
         if self.mode == "spring" and mode != "spring":
             self.ui.spring_tool.cancel()
+        if self.mode == "bend" and mode != "bend":
+            self.ui.bend_tool.cancel()
         if self.mode == "env" and mode != "env":
             self.ui.env_tool.cancel()
 
@@ -78,6 +83,8 @@ class BuilderApp:
             self.ui.particle_tool.start()
         if mode == "spring":
             self.ui.spring_tool.start()
+        if mode == "bend":
+            self.ui.bend_tool.start()
         if mode == "env":
             self.ui.env_tool.start()
         if mode != "spring":
@@ -264,6 +271,8 @@ class BuilderApp:
                         self.set_mode("particle")
                     elif e.key == pygame.K_3:
                         self.set_mode("spring")
+                    elif e.key == pygame.K_9:
+                        self.set_mode("bend")
                     elif e.key == pygame.K_4:
                         self.set_mode("delete")
                     elif e.key == pygame.K_5:
@@ -392,7 +401,7 @@ class BuilderApp:
                     p.prev_pos.y = p.pos.y
 
             self.screen.fill((30, 30, 30))
-            self.renderer.draw(self.particles, self.springs)
+            self.renderer.draw(self.particles, self.springs, self.bending_springs)
             self.ui.draw()
             # highlight first spring particle
             if self.spring_first is not None and self.mode == "spring":


### PR DESCRIPTION
## Summary
- support drawing bending springs in `Renderer`
- add `BendingSpringTool` to `builder_ui` and expose a "Bend" sidebar button
- update `start_create` so bending springs can be built and rendered
- document new controls in README and AGENTS

## Testing
- `python -m py_compile renderer.py builder_ui.py start_create.py bending_spring.py physics.py`

------
https://chatgpt.com/codex/tasks/task_e_688a90ca014c8325883484d6645f8b4d