### PR TITLE
Add save/load feature for builder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,3 +58,4 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
   or a manual value. Inspect mode can modify their angle and stiffness later.
 - Builder sidebar now has **Save** and **Load** buttons for exporting and
   importing scene states.
+- Loading a saved scene now refreshes the physics engine so simulations resume.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This repository contains small pygame demos for 2D particle-based physics simula
 - `structures.py` – helper routines for building walls, rods and other shapes.
 - `builder_ui.py` – sidebar UI widgets used by the interactive builder.
 - `color_picker.py` – colour picker helper using Tkinter.
+- `file_dialog.py` – opens save/load dialogs in a separate process.
 - `start_create.py` – interactive builder for constructing scenes.
 - `start.py` – demo of a soft cell made from three circular walls.
 - `start_basic.py` – minimal ring of particles demo.
@@ -55,3 +56,5 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
   They render as yellow dashed hinges and their rest angle and stiffness are editable.
 - A toggle lets bending springs use the current angle of the selected particles
   or a manual value. Inspect mode can modify their angle and stiffness later.
+- Builder sidebar now has **Save** and **Load** buttons for exporting and
+  importing scene states.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **N/M** – decrease/increase simulation temperature
 * **P** – pause or resume the physics update
 * Use the **Save** and **Load** buttons in the sidebar to export or import the
-  current scene as a JSON file.
+  current scene as a JSON file. Loaded scenes automatically resume simulation.
 
 Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. The sidebar fields let you set the arm's mass, radius, stiffness, cycle speed, colours and adhesion factor before creation, and any number of arms may share the same cycle key. The **Inspect** tool can select a particle or a spring so their properties (colour, mass, radius, rest length, stiffness, **max force** and visibility) may be edited in place.  A value of ``0`` for max force disables the limit. Use the Particle, Spring or Env buttons to reveal their respective sliders.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 
 ## Features
 
-* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and various environment settings like temperature, gravity, repulsion and damping. Tools exist for circles, rods, bending springs, flexible hook arms and an inspect mode for tweaking existing particles and springs. Bending springs may use the current angle of the selected particles or a manual value. Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle, spring and environment controls each have their own button in the sidebar.
+* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and various environment settings like temperature, gravity, repulsion and damping. Tools exist for circles, rods, bending springs, flexible hook arms and an inspect mode for tweaking existing particles and springs. Bending springs may use the current angle of the selected particles or a manual value. Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle, spring and environment controls each have their own button in the sidebar. The builder can also save or load the entire scene using sidebar buttons.
 * **Demo scenes** – other `start_*.py` files showcase different preset configurations (e.g. cell walls, rods or gradient walls).  They are good starting points for custom experiments.
 * **Modular codebase** – the core simulation is split into small modules:
   * `particle.py` – a point mass implemented with Verlet integration.
@@ -68,6 +68,8 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **K/L** – decrease/increase spring stiffness
 * **N/M** – decrease/increase simulation temperature
 * **P** – pause or resume the physics update
+* Use the **Save** and **Load** buttons in the sidebar to export or import the
+  current scene as a JSON file.
 
 Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. The sidebar fields let you set the arm's mass, radius, stiffness, cycle speed, colours and adhesion factor before creation, and any number of arms may share the same cycle key. The **Inspect** tool can select a particle or a spring so their properties (colour, mass, radius, rest length, stiffness, **max force** and visibility) may be edited in place.  A value of ``0`` for max force disables the limit. Use the Particle, Spring or Env buttons to reveal their respective sliders.
 

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -1405,6 +1405,8 @@ class SidebarUI:
         add_button("Inspect", lambda: self.app.set_mode("inspect"))
         add_button("Env", lambda: self.app.set_mode("env"))
         add_button("Delete", lambda: self.app.set_mode("delete"))
+        add_button("Save", self.app.save_state_dialog)
+        add_button("Load", self.app.load_state_dialog)
         add_button(lambda: "Resume" if self.app.paused else "Pause", self.app.toggle_pause)
 
         y += 10

--- a/file_dialog.py
+++ b/file_dialog.py
@@ -1,0 +1,55 @@
+"""File dialog utilities using Tkinter in a subprocess."""
+
+from multiprocessing import Pipe, Process
+from typing import Optional
+
+
+
+def _save_process(initial: str, conn) -> None:
+    try:
+        from tkinter import Tk, filedialog
+        root = Tk()
+        root.withdraw()
+        path = filedialog.asksaveasfilename(
+            defaultextension=".json",
+            initialfile=initial,
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
+        )
+        root.destroy()
+    except Exception:
+        path = None
+    conn.send(path)
+    conn.close()
+
+
+def _open_process(conn) -> None:
+    try:
+        from tkinter import Tk, filedialog
+        root = Tk()
+        root.withdraw()
+        path = filedialog.askopenfilename(
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")]
+        )
+        root.destroy()
+    except Exception:
+        path = None
+    conn.send(path)
+    conn.close()
+
+
+def choose_save_path(initial: str = "scene.json") -> Optional[str]:
+    parent_conn, child_conn = Pipe()
+    process = Process(target=_save_process, args=(initial, child_conn))
+    process.start()
+    path = parent_conn.recv()
+    process.join()
+    return path
+
+
+def choose_open_path() -> Optional[str]:
+    parent_conn, child_conn = Pipe()
+    process = Process(target=_open_process, args=(child_conn,))
+    process.start()
+    path = parent_conn.recv()
+    process.join()
+    return path

--- a/start_create.py
+++ b/start_create.py
@@ -1,5 +1,6 @@
 import pygame
 import math
+import json
 
 from particle import Particle
 from spring import Spring
@@ -7,6 +8,7 @@ from physics import PhysicsEngine
 from bending_spring import BendingSpring
 from renderer import Renderer
 from builder_ui import SidebarUI
+from file_dialog import choose_save_path, choose_open_path
 from structures import create_rod as structure_create_rod
 from hook_arm import HookArm
 
@@ -166,6 +168,149 @@ class BuilderApp:
 
     def toggle_pause(self):
         self.paused = not self.paused
+
+    # ------------------------------------------------------------------ save/load
+    def save_state_dialog(self):
+        path = choose_save_path("scene.json")
+        if path:
+            self.save_state(path)
+
+    def load_state_dialog(self):
+        path = choose_open_path()
+        if path:
+            self.load_state(path)
+
+    def save_state(self, path: str):
+        data = {
+            "particles": [
+                {
+                    "pos": [p.pos.x, p.pos.y],
+                    "prev": [p.prev_pos.x, p.prev_pos.y],
+                    "mass": p.mass,
+                    "radius": p.radius,
+                    "color": list(p.color) if p.color else None,
+                    "tag": p.tag,
+                    "fixed": p.fixed,
+                }
+                for p in self.particles
+            ],
+            "springs": [
+                {
+                    "p1": self.particles.index(s.p1),
+                    "p2": self.particles.index(s.p2),
+                    "rest": s.rest_length,
+                    "stiff": s.stiffness,
+                    "max": s.max_force,
+                    "invis": s.invisible,
+                }
+                for s in self.springs
+            ],
+            "bending": [
+                {
+                    "p1": self.particles.index(bs.p1),
+                    "p2": self.particles.index(bs.p2),
+                    "p3": self.particles.index(bs.p3),
+                    "angle": bs.rest_angle,
+                    "stiff": bs.stiffness,
+                }
+                for bs in self.bending_springs
+            ],
+            "arms": [
+                {
+                    "particles": [self.particles.index(p) for p in arm.particles],
+                    "springs": [self.springs.index(s) for s in arm.springs],
+                    "rest_lengths": arm.rest_lengths,
+                    "max_lengths": arm.max_lengths,
+                    "cycle_speed": arm.cycle_speed,
+                    "color": list(arm.color),
+                    "high_color": list(arm.high_drag_color),
+                    "adhesion": arm.adhesion_mass_factor,
+                    "orig_mass": arm._orig_mass,
+                    "cycle_key": arm.cycle_key,
+                }
+                for arm in self.arms
+            ],
+            "physics": {
+                "gravity": [self.physics.gravity.x, self.physics.gravity.y],
+                "repulsion_radius": self.physics.repulsion_radius,
+                "repulsion_strength": self.physics.repulsion_strength,
+                "temperature": self.physics.temperature,
+                "damping_coeff": self.physics.damping_coeff,
+            },
+        }
+        with open(path, "w") as fh:
+            json.dump(data, fh, indent=2)
+
+    def load_state(self, path: str):
+        with open(path, "r") as fh:
+            data = json.load(fh)
+
+        self.particles = []
+        for pd in data.get("particles", []):
+            p = Particle(
+                pd["pos"],
+                mass=pd.get("mass", 1.0),
+                color=tuple(pd["color"]) if pd.get("color") else None,
+                radius=pd.get("radius"),
+                tag=pd.get("tag"),
+            )
+            p.prev_pos = pygame.Vector2(pd.get("prev", pd["pos"]))
+            p.fixed = pd.get("fixed", False)
+            self.particles.append(p)
+
+        self.springs = []
+        for sd in data.get("springs", []):
+            s = Spring(
+                self.particles[sd["p1"]],
+                self.particles[sd["p2"]],
+                sd.get("rest", 0),
+                stiffness=sd.get("stiff", 200.0),
+                max_force=sd.get("max"),
+                invisible=sd.get("invis", False),
+            )
+            self.springs.append(s)
+
+        self.bending_springs = []
+        for bd in data.get("bending", []):
+            bs = BendingSpring(
+                self.particles[bd["p1"]],
+                self.particles[bd["p2"]],
+                self.particles[bd["p3"]],
+                bd.get("angle", 0),
+                bd.get("stiff", 0),
+            )
+            self.bending_springs.append(bs)
+
+        self.arms = []
+        self.cycle_keys = {}
+        for ad in data.get("arms", []):
+            arm = HookArm.__new__(HookArm)
+            arm.particles = [self.particles[i] for i in ad["particles"]]
+            arm.springs = [self.springs[i] for i in ad["springs"]]
+            arm.color = tuple(ad["color"])
+            arm.high_drag_color = tuple(ad["high_color"])
+            arm.adhesion_mass_factor = ad.get("adhesion", 10.0)
+            arm.cycle_speed = ad.get("cycle_speed", 240.0)
+            arm.rest_lengths = ad.get("rest_lengths", [s.rest_length for s in arm.springs])
+            arm.max_lengths = ad.get("max_lengths", [r * 4 for r in arm.rest_lengths])
+            arm.tip = arm.particles[-1]
+            arm._orig_mass = ad.get("orig_mass", arm.tip.mass)
+            arm.extend_held = False
+            arm.contract_held = False
+            arm.cycle_held = False
+            arm.cycle_active = False
+            arm.cycle_phase = 0
+            arm.cycle_key = ad.get("cycle_key")
+            if arm.cycle_key is not None:
+                self.cycle_keys.setdefault(arm.cycle_key, []).append(arm)
+            self.arms.append(arm)
+
+        phys = data.get("physics", {})
+        self.physics.gravity = pygame.Vector2(phys.get("gravity", [0, 0]))
+        self.physics.repulsion_radius = phys.get("repulsion_radius", 20)
+        self.physics.repulsion_strength = phys.get("repulsion_strength", 100)
+        self.physics.temperature = phys.get("temperature", 0)
+        self.physics.damping_coeff = phys.get("damping_coeff", 1)
 
     # ------------------------------------------------------------------ circle creation
     def create_circle(self, center: pygame.Vector2, radius: float, segments: int):

--- a/start_create.py
+++ b/start_create.py
@@ -312,6 +312,11 @@ class BuilderApp:
         self.physics.temperature = phys.get("temperature", 0)
         self.physics.damping_coeff = phys.get("damping_coeff", 1)
 
+        # refresh physics engine references so loaded objects are simulated
+        self.physics.particles = self.particles
+        self.physics.springs = self.springs
+        self.physics.bending_springs = self.bending_springs
+
     # ------------------------------------------------------------------ circle creation
     def create_circle(self, center: pygame.Vector2, radius: float, segments: int):
         particles = []


### PR DESCRIPTION
## Summary
- add utility for save/load dialogs
- include Save and Load buttons in sidebar
- support saving and loading full scene state in `start_create.py`
- document new functionality in README and AGENTS

## Testing
- `python start_create.py` *(fails: No module named 'pygame')*
- `pip install pygame` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d2eb6b1b88325b7dfab83d42952b0