### PR TITLE
Add grid overlay and snapping to builder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,4 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
   importing scene states.
 - Loading a saved scene now refreshes the physics engine so simulations resume.
 - Circle and rod tools now expose spring stiffness sliders and can add bending springs along their outline.
+- A new **Grid** tool can overlay a configurable grid; enabling it snaps new particles to the nearest intersection.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
 
 ## Features
 
-* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and various environment settings like temperature, gravity, repulsion and damping. Tools exist for circles, rods, bending springs, flexible hook arms and an inspect mode for tweaking existing particles and springs. Circles and rods now have per-shape stiffness sliders and an option to add bending springs along their outline. Bending springs may use the current angle of the selected particles or a manual value. Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle, spring and environment controls each have their own button in the sidebar. The builder can also save or load the entire scene using sidebar buttons.
+* **Interactive builder** – `start_create.py` opens a window where you can drag particles, connect them with springs and spawn predefined structures.  A sidebar UI contains sliders to tweak parameters such as mass, radius, spring stiffness and various environment settings like temperature, gravity, repulsion and damping. Tools exist for circles, rods, bending springs, flexible hook arms and an inspect mode for tweaking existing particles and springs. Circles and rods now have per-shape stiffness sliders and an option to add bending springs along their outline. Bending springs may use the current angle of the selected particles or a manual value. Arm creation now exposes mass, radius, colour, adhesion settings and cycle speed per arm. Particle, spring and environment controls each have their own button in the sidebar. The builder can also save or load the entire scene using sidebar buttons. A dedicated **Grid** tool toggles a grid overlay and lets you adjust its spacing; newly created particles snap to grid intersections while it is enabled.
 * **Demo scenes** – other `start_*.py` files showcase different preset configurations (e.g. cell walls, rods or gradient walls).  They are good starting points for custom experiments.
 * **Modular codebase** – the core simulation is split into small modules:
   * `particle.py` – a point mass implemented with Verlet integration.
@@ -68,6 +68,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
 * **K/L** – decrease/increase spring stiffness
 * **N/M** – decrease/increase simulation temperature
 * **P** – pause or resume the physics update
+* Use the **Grid** button in the sidebar to toggle a grid overlay and adjust its spacing. While active, new particles snap to the grid.
 * Use the **Save** and **Load** buttons in the sidebar to export or import the
   current scene as a JSON file. Loaded scenes automatically resume simulation.
 

--- a/builder_ui.py
+++ b/builder_ui.py
@@ -440,6 +440,59 @@ class BendingSpringTool:
         return False
 
 
+class GridTool:
+    """Toggle a grid overlay and adjust its spacing."""
+
+    def __init__(self, sidebar: 'SidebarUI'):
+        self.sidebar = sidebar
+        self.app = sidebar.app
+        self.active = False
+
+        x = sidebar.screen.get_width() - sidebar.WIDTH + 10
+        width = sidebar.WIDTH - 20
+        y = sidebar.extra_start_y
+
+        self.toggle_rect = pygame.Rect(x, y, width, SidebarUI.BUTTON_HEIGHT)
+        y += SidebarUI.BUTTON_HEIGHT + 12
+        self.size_field = SliderField(
+            "Spacing", 5, 200, lambda: self.app.grid_size, self.app.set_grid_size, x, y, width
+        )
+
+    # ---------------- control
+    def start(self):
+        self.active = True
+
+    def cancel(self):
+        self.active = False
+
+    # ---------------- drawing
+    def draw_ui(self):
+        if not self.active or not self.sidebar.visible:
+            return
+        pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.toggle_rect)
+        state = "On" if self.app.grid_enabled else "Off"
+        txt = self.sidebar.font.render(f"Grid: {state}", True, (255, 255, 255))
+        rect = txt.get_rect(center=self.toggle_rect.center)
+        self.sidebar.screen.blit(txt, rect)
+        self.size_field.draw(self.sidebar.screen)
+
+    def draw_preview(self):
+        pass
+
+    # ---------------- event handling
+    def handle_event(self, event):
+        if not self.active:
+            return False
+        if self.sidebar.visible:
+            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                if self.toggle_rect.collidepoint(event.pos):
+                    self.app.toggle_grid()
+                    return True
+            if self.size_field.handle_event(event):
+                return True
+        return False
+
+
 class EnvironmentTool:
     """Expose global simulation options such as gravity and temperature."""
 
@@ -624,13 +677,17 @@ class CircleTool:
             return
         screen = self.sidebar.screen
         color = (150, 150, 150)
-        center = (int(self.center.x), int(self.center.y))
-        pygame.draw.circle(screen, color, center, int(self.radius), 1)
+        center = self.app.snap_to_grid(self.center)
+        pygame.draw.circle(screen, color, (int(center.x), int(center.y)), int(self.radius), 1)
         for i in range(self.segments):
             theta1 = (i / self.segments) * 2 * math.pi
             theta2 = ((i + 1) % self.segments) / self.segments * 2 * math.pi
-            p1 = self.center + pygame.Vector2(math.cos(theta1), math.sin(theta1)) * self.radius
-            p2 = self.center + pygame.Vector2(math.cos(theta2), math.sin(theta2)) * self.radius
+            p1 = self.app.snap_to_grid(
+                self.center + pygame.Vector2(math.cos(theta1), math.sin(theta1)) * self.radius
+            )
+            p2 = self.app.snap_to_grid(
+                self.center + pygame.Vector2(math.cos(theta2), math.sin(theta2)) * self.radius
+            )
             pygame.draw.line(screen, color, p1, p2, 1)
             pygame.draw.circle(screen, color, (int(p1.x), int(p1.y)), self.app.radius, 1)
 
@@ -669,11 +726,12 @@ class CircleTool:
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             # click in world area to set center
             if event.pos[0] < self.sidebar.screen.get_width() - self.sidebar.visible_width():
-                self.center = pygame.Vector2(event.pos)
+                self.center = self.app.snap_to_grid(pygame.Vector2(event.pos))
                 self.dragging = True
                 return True
         elif event.type == pygame.MOUSEMOTION and self.dragging:
-            self.radius = (pygame.Vector2(event.pos) - self.center).length()
+            mouse = self.app.snap_to_grid(pygame.Vector2(event.pos))
+            self.radius = (mouse - self.center).length()
             return True
         elif event.type == pygame.MOUSEBUTTONUP and event.button == 1 and self.dragging:
             self.dragging = False
@@ -792,7 +850,7 @@ class RodTool:
                 pos = pygame.Vector2(
                     center_right.x - (s - 2 * math.pi * radius - length), center.y + radius
                 )
-            pts.append(pos)
+            pts.append(self.app.snap_to_grid(pos))
         return pts
 
     # ---------------- drawing
@@ -944,11 +1002,12 @@ class RodTool:
 
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             if event.pos[0] < self.sidebar.screen.get_width() - self.sidebar.visible_width():
-                self.center = pygame.Vector2(event.pos)
+                self.center = self.app.snap_to_grid(pygame.Vector2(event.pos))
                 self.dragging = True
                 return True
         elif event.type == pygame.MOUSEMOTION and self.dragging:
-            self.length = abs(event.pos[0] - self.center.x) * 2
+            mouse = self.app.snap_to_grid(pygame.Vector2(event.pos))
+            self.length = abs(mouse.x - self.center.x) * 2
             return True
         elif event.type == pygame.MOUSEBUTTONUP and event.button == 1 and self.dragging:
             self.dragging = False
@@ -1075,7 +1134,7 @@ class HookArmTool:
         pts = []
         for i in range(1, self.segments + 1):
             pos = self.base.pos + dir_norm * self.spacing * i
-            pts.append(pos)
+            pts.append(self.app.snap_to_grid(pos))
         return pts
 
     def draw_ui(self):
@@ -1166,7 +1225,8 @@ class HookArmTool:
                     self.dragging = True
                     return True
         elif event.type == pygame.MOUSEMOTION and self.dragging:
-            self.direction = pygame.Vector2(event.pos) - self.base.pos
+            mouse = self.app.snap_to_grid(pygame.Vector2(event.pos))
+            self.direction = mouse - self.base.pos
             return True
         elif event.type == pygame.MOUSEBUTTONUP and event.button == 1 and self.dragging:
             self.dragging = False
@@ -1465,6 +1525,7 @@ class SidebarUI:
         self.circle_tool = CircleTool(self)
         self.rod_tool = RodTool(self)
         self.arm_tool = HookArmTool(self)
+        self.grid_tool = GridTool(self)
         self.env_tool = EnvironmentTool(self)
         self.inspect_tool = InspectTool(self)
 
@@ -1488,6 +1549,7 @@ class SidebarUI:
         add_button("Rod", lambda: self.app.set_mode("rod"))
         add_button("Arm", lambda: self.app.set_mode("arm"))
         add_button("Inspect", lambda: self.app.set_mode("inspect"))
+        add_button("Grid", lambda: self.app.set_mode("grid"))
         add_button("Env", lambda: self.app.set_mode("env"))
         add_button("Delete", lambda: self.app.set_mode("delete"))
         add_button("Save", self.app.save_state_dialog)
@@ -1528,6 +1590,7 @@ class SidebarUI:
             self.circle_tool.draw_ui()
             self.rod_tool.draw_ui()
             self.arm_tool.draw_ui()
+            self.grid_tool.draw_ui()
             self.env_tool.draw_ui()
             self.inspect_tool.draw_ui()
 
@@ -1538,6 +1601,7 @@ class SidebarUI:
         self.circle_tool.draw_preview()
         self.rod_tool.draw_preview()
         self.arm_tool.draw_preview()
+        self.grid_tool.draw_preview()
         self.env_tool.draw_preview()
         self.inspect_tool.draw_preview()
 
@@ -1578,6 +1642,8 @@ class SidebarUI:
         if self.rod_tool.handle_event(event):
             return True
         if self.arm_tool.handle_event(event):
+            return True
+        if self.grid_tool.handle_event(event):
             return True
         if self.env_tool.handle_event(event):
             return True

--- a/start_create.py
+++ b/start_create.py
@@ -38,6 +38,8 @@ class BuilderApp:
         self.radius = 10
         self.color = (255, 0, 0)
         self.stiffness = 200.0
+        self.grid_enabled = False
+        self.grid_size = 40.0
 
         self.font = pygame.font.SysFont(None, 24)
         self.physics = PhysicsEngine(
@@ -71,6 +73,8 @@ class BuilderApp:
             self.ui.bend_tool.cancel()
         if self.mode == "env" and mode != "env":
             self.ui.env_tool.cancel()
+        if self.mode == "grid" and mode != "grid":
+            self.ui.grid_tool.cancel()
 
         self.mode = mode
         if mode == "circle":
@@ -89,6 +93,8 @@ class BuilderApp:
             self.ui.bend_tool.start()
         if mode == "env":
             self.ui.env_tool.start()
+        if mode == "grid":
+            self.ui.grid_tool.start()
         if mode != "spring":
             self.spring_first = None
         if self.selected and mode != "drag":
@@ -168,6 +174,22 @@ class BuilderApp:
 
     def toggle_pause(self):
         self.paused = not self.paused
+
+    def toggle_grid(self):
+        """Enable or disable the placement grid."""
+        self.grid_enabled = not self.grid_enabled
+
+    def set_grid_size(self, value: float):
+        """Set the grid spacing in pixels."""
+        self.grid_size = max(5.0, value)
+
+    def snap_to_grid(self, vec: pygame.Vector2) -> pygame.Vector2:
+        """Return ``vec`` snapped to the nearest grid intersection."""
+        if not self.grid_enabled:
+            return vec
+        x = round(vec.x / self.grid_size) * self.grid_size
+        y = round(vec.y / self.grid_size) * self.grid_size
+        return pygame.Vector2(x, y)
 
     # ------------------------------------------------------------------ save/load
     def save_state_dialog(self):
@@ -328,11 +350,13 @@ class BuilderApp:
         bend_stiffness: float,
     ):
         """Spawn a ring of particles with optional bending springs."""
+        center = self.snap_to_grid(center)
         particles = []
         springs = []
         for i in range(segments):
             theta = (i / segments) * 2 * math.pi
             pos = center + pygame.Vector2(math.cos(theta), math.sin(theta)) * radius
+            pos = self.snap_to_grid(pos)
             p = Particle(pos, mass=self.mass, color=self.color, radius=self.radius)
             particles.append(p)
         for i in range(segments):
@@ -390,6 +414,10 @@ class BuilderApp:
         arm.cycle_key = cycle_key
         if cycle_key is not None:
             self.cycle_keys.setdefault(cycle_key, []).append(arm)
+        if self.grid_enabled:
+            for p in arm.particles:
+                p.pos = self.snap_to_grid(p.pos)
+                p.prev_pos = p.pos.copy()
         self.arms.append(arm)
         self.particles.extend(arm.particles)
         self.springs.extend(arm.springs)
@@ -408,6 +436,7 @@ class BuilderApp:
         bend_stiffness: float,
     ):
         """Create a capsule-shaped rod with optional bending springs."""
+        center = self.snap_to_grid(center)
         particles, springs = structure_create_rod(
             center,
             radius=radius,
@@ -426,6 +455,8 @@ class BuilderApp:
             p.mass = self.mass
             p.radius = self.radius
             p.color = self.color
+            p.pos = self.snap_to_grid(p.pos)
+            p.prev_pos = p.pos.copy()
         self.particles.extend(particles)
         self.springs.extend(springs)
         if add_bending:
@@ -512,6 +543,7 @@ class BuilderApp:
 
                 elif e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
                     mouse = pygame.Vector2(e.pos)
+                    snap_mouse = self.snap_to_grid(mouse)
                     if self.mode == "drag":
                         if self.particles:
                             self.selected = min(
@@ -519,7 +551,7 @@ class BuilderApp:
                             )
                             self.selected.fixed = True
                     elif self.mode == "particle":
-                        p = Particle(mouse, mass=self.mass, color=self.color, radius=self.radius)
+                        p = Particle(snap_mouse, mass=self.mass, color=self.color, radius=self.radius)
                         self.particles.append(p)
                     elif self.mode == "spring":
                         if self.particles:
@@ -595,6 +627,13 @@ class BuilderApp:
                     p.prev_pos.y = p.pos.y
 
             self.screen.fill((30, 30, 30))
+            if self.grid_enabled:
+                max_x = self.screen.get_width() - self.ui.visible_width()
+                max_y = self.screen.get_height()
+                for gx in range(0, int(max_x) + 1, int(self.grid_size)):
+                    pygame.draw.line(self.screen, (60, 60, 60), (gx, 0), (gx, max_y))
+                for gy in range(0, int(max_y) + 1, int(self.grid_size)):
+                    pygame.draw.line(self.screen, (60, 60, 60), (0, gy), (max_x, gy))
             self.renderer.draw(self.particles, self.springs, self.bending_springs)
             self.ui.draw()
             # highlight first spring particle


### PR DESCRIPTION
## Summary
- Add Grid tool to sidebar with toggle button and spacing slider
- Snap new shapes to grid intersections and render configurable grid
- Document new Grid feature

## Testing
- `python -m py_compile builder_ui.py start_create.py`
- `SDL_VIDEODRIVER=dummy python start_create.py` *(fails: ModuleNotFoundError: No module named 'pygame')*
- `pip install pygame` *(fails: Could not find a version that satisfies the requirement pygame)*

------
https://chatgpt.com/codex/tasks/task_e_688e734fe2ec8325a4c310ff2392cd41