### PR TITLE
Refactor builder tools around shared base class

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,5 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - A new **Grid** tool can overlay a configurable grid; enabling it snaps new particles to the nearest intersection.
 - Sidebar includes an **Undo** button to revert the most recent change.
 - Rod tool preview now renders correctly through a dedicated `draw_preview` method.
+- Builder tools now share a common `Tool` base class providing default
+  `start`, `cancel`, drawing and event hooks to reduce boilerplate.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
     Brownian noise.
   * `renderer.py` – draws particles and springs to the pygame window.
   * `structures.py` – helper functions to build shapes like circular walls or rods.
-  * `builder_ui/` and `color_picker.py` – the sidebar widgets and the cross‑platform colour selection utility.
+  * `builder_ui/` and `color_picker.py` – the sidebar widgets and the cross‑platform colour selection utility. Tools in this
+    package inherit from a small :class:`Tool` base class that provides
+    default lifecycle, drawing and event hooks.
   * **High-drag adhesion** – set a particle's ``tag`` to ``"high_drag"`` and the
     physics engine multiplies its viscous drag, causing it to stick in place.
   * **Weighted adhesion** – a ``HookArm`` tip also increases in mass when stuck

--- a/builder_ui/tools/base.py
+++ b/builder_ui/tools/base.py
@@ -1,0 +1,69 @@
+"""Common interface for sidebar tools.
+
+This module defines :class:`Tool`, a small base class used by the
+sidebar tools.  It centralises the ``start``/``cancel`` lifecycle
+and provides no-op hooks for drawing and event handling.  Subclasses
+can override whichever behaviour they require.
+"""
+
+from __future__ import annotations
+
+
+class Tool:
+    """Minimal base class for sidebar tools.
+
+    Parameters
+    ----------
+    sidebar:
+        The :class:`builder_ui.sidebar.SidebarUI` instance owning the
+        tool.  A reference to ``sidebar.app`` is exposed as ``self.app``
+        for convenience.
+    """
+
+    def __init__(self, sidebar: "SidebarUI") -> None:
+        self.sidebar = sidebar
+        self.app = sidebar.app
+        self.active = False
+
+    # ---------------- lifecycle -------------------------------------------------
+    def start(self) -> None:
+        """Activate the tool."""
+        self.active = True
+
+    def cancel(self) -> None:
+        """Deactivate the tool."""
+        self.active = False
+
+    # ---------------- drawing ---------------------------------------------------
+    def draw_ui(self) -> bool:
+        """Return ``True`` if the tool should draw its UI.
+
+        Subclasses should start their ``draw_ui`` implementation with::
+
+            if not super().draw_ui():
+                return
+
+        The default method simply checks whether the tool is active and the
+        sidebar is visible.
+        """
+
+        return self.active and getattr(self.sidebar, "visible", True)
+
+    def draw_preview(self) -> bool:
+        """Return ``True`` if the tool should draw a world-space preview."""
+        return self.active
+
+    # ---------------- events ----------------------------------------------------
+    def handle_event(self, event) -> bool:  # pragma: no cover - trivial
+        """Return ``True`` if the tool should handle ``event``.
+
+        Subclasses typically call ``super().handle_event(event)`` and abort if
+        it returns ``False``::
+
+            if not super().handle_event(event):
+                return False
+
+        The default simply checks ``self.active``.
+        """
+
+        return self.active

--- a/builder_ui/tools/bending_spring_tool.py
+++ b/builder_ui/tools/bending_spring_tool.py
@@ -5,15 +5,14 @@ import pygame
 
 from bending_spring import BendingSpring
 from ..fields import SliderField
+from .base import Tool
 
 
-class BendingSpringTool:
+class BendingSpringTool(Tool):
     """Create a bending spring by choosing three particles."""
 
     def __init__(self, sidebar: 'SidebarUI'):
-        self.sidebar = sidebar
-        self.app = sidebar.app
-        self.active = False
+        super().__init__(sidebar)
         self.angle = 90.0
         self.stiffness = 200.0
         self.auto_angle = False
@@ -43,17 +42,17 @@ class BendingSpringTool:
 
     # ---------------- control
     def start(self):
-        self.active = True
+        super().start()
         self.auto_angle = False
         self.selected.clear()
 
     def cancel(self):
-        self.active = False
+        super().cancel()
         self.selected.clear()
 
     # ---------------- drawing
     def draw_ui(self):
-        if not self.active or not self.sidebar.visible:
+        if not super().draw_ui():
             return
         if not self.auto_angle:
             self.angle_field.draw(self.sidebar.screen)
@@ -69,7 +68,7 @@ class BendingSpringTool:
         self.sidebar.screen.blit(txt, rect)
 
     def draw_preview(self):
-        if not self.active:
+        if not super().draw_preview():
             return
         screen = self.sidebar.screen
         color = (150, 150, 150)
@@ -82,7 +81,7 @@ class BendingSpringTool:
 
     # ---------------- event handling
     def handle_event(self, event):
-        if not self.active:
+        if not super().handle_event(event):
             return False
 
         if self.sidebar.visible:

--- a/builder_ui/tools/circle_tool.py
+++ b/builder_ui/tools/circle_tool.py
@@ -4,15 +4,14 @@ import math
 import pygame
 
 from ..fields import SliderField
+from .base import Tool
 
 
-class CircleTool:
+class CircleTool(Tool):
     """Handle circle preview creation with sliders and dragging."""
 
     def __init__(self, sidebar: 'SidebarUI'):
-        self.sidebar = sidebar
-        self.app = sidebar.app
-        self.active = False
+        super().__init__(sidebar)
         self.center = None
         self.radius = 50.0
         self.segments = 8
@@ -60,20 +59,18 @@ class CircleTool:
 
     # ---------------- control
     def start(self):
-        self.active = True
+        super().start()
         self.center = None
         self.stiffness = self.app.stiffness
         self.bend_stiffness = self.app.stiffness
         self.include_bend = False
-        self.stiffness = self.app.stiffness
-        self.bend_stiffness = self.app.stiffness
 
     def cancel(self):
-        self.active = False
+        super().cancel()
         self.dragging = False
 
     def draw_ui(self):
-        if not self.active or not self.sidebar.visible:
+        if not super().draw_ui():
             return
         self.radius_field.draw(self.sidebar.screen)
         self.segments_field.draw(self.sidebar.screen)
@@ -91,7 +88,7 @@ class CircleTool:
         self.sidebar.screen.blit(txt, rect)
 
     def draw_preview(self):
-        if not self.active or self.center is None:
+        if not super().draw_preview() or self.center is None:
             return
         screen = self.sidebar.screen
         color = (150, 150, 150)
@@ -111,7 +108,7 @@ class CircleTool:
 
     # ---------------- event handling
     def handle_event(self, event):
-        if not self.active:
+        if not super().handle_event(event):
             return False
 
         if self.sidebar.visible:

--- a/builder_ui/tools/environment_tool.py
+++ b/builder_ui/tools/environment_tool.py
@@ -3,15 +3,14 @@
 import pygame
 
 from ..fields import SliderField
+from .base import Tool
 
 
-class EnvironmentTool:
+class EnvironmentTool(Tool):
     """Expose global simulation options such as gravity and temperature."""
 
     def __init__(self, sidebar: 'SidebarUI'):
-        self.sidebar = sidebar
-        self.app = sidebar.app
-        self.active = False
+        super().__init__(sidebar)
 
         x = sidebar.screen.get_width() - sidebar.WIDTH + 10
         width = sidebar.WIDTH - 20
@@ -59,16 +58,9 @@ class EnvironmentTool:
             x, y, width,
         )
 
-    # ---------------- control
-    def start(self):
-        self.active = True
-
-    def cancel(self):
-        self.active = False
-
     # ---------------- drawing
     def draw_ui(self):
-        if not self.active or not self.sidebar.visible:
+        if not super().draw_ui():
             return
         self.gx_field.draw(self.sidebar.screen)
         self.gy_field.draw(self.sidebar.screen)
@@ -77,12 +69,9 @@ class EnvironmentTool:
         self.damp_field.draw(self.sidebar.screen)
         self.temp_field.draw(self.sidebar.screen)
 
-    def draw_preview(self):
-        pass
-
     # ---------------- event handling
     def handle_event(self, event):
-        if not self.active:
+        if not super().handle_event(event):
             return False
         if self.sidebar.visible:
             if self.gx_field.handle_event(event):

--- a/builder_ui/tools/grid_tool.py
+++ b/builder_ui/tools/grid_tool.py
@@ -3,15 +3,14 @@
 import pygame
 
 from ..fields import SliderField
+from .base import Tool
 
 
-class GridTool:
+class GridTool(Tool):
     """Toggle a grid overlay and adjust its spacing."""
 
     def __init__(self, sidebar: 'SidebarUI'):
-        self.sidebar = sidebar
-        self.app = sidebar.app
-        self.active = False
+        super().__init__(sidebar)
 
         x = sidebar.screen.get_width() - sidebar.WIDTH + 10
         width = sidebar.WIDTH - 20
@@ -23,16 +22,9 @@ class GridTool:
             "Spacing", 5, 200, lambda: self.app.grid_size, self.app.set_grid_size, x, y, width
         )
 
-    # ---------------- control
-    def start(self):
-        self.active = True
-
-    def cancel(self):
-        self.active = False
-
     # ---------------- drawing
     def draw_ui(self):
-        if not self.active or not self.sidebar.visible:
+        if not super().draw_ui():
             return
         pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.toggle_rect)
         state = "On" if self.app.grid_enabled else "Off"
@@ -41,12 +33,9 @@ class GridTool:
         self.sidebar.screen.blit(txt, rect)
         self.size_field.draw(self.sidebar.screen)
 
-    def draw_preview(self):
-        pass
-
     # ---------------- event handling
     def handle_event(self, event):
-        if not self.active:
+        if not super().handle_event(event):
             return False
         if self.sidebar.visible:
             if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:

--- a/builder_ui/tools/hook_arm_tool.py
+++ b/builder_ui/tools/hook_arm_tool.py
@@ -3,9 +3,10 @@
 import pygame
 
 from ..fields import SliderField, ColorField, KeyField
+from .base import Tool
 
 
-class HookArmTool:
+class HookArmTool(Tool):
     """Preview and creation helper for :class:`HookArm` instances.
 
     The tool lets the user configure segment count, spacing, particle
@@ -14,9 +15,7 @@ class HookArmTool:
     """
 
     def __init__(self, sidebar: 'SidebarUI'):
-        self.sidebar = sidebar
-        self.app = sidebar.app
-        self.active = False
+        super().__init__(sidebar)
         self.base = None
         self.direction = pygame.Vector2(1, 0)
         self.segments = 3
@@ -106,11 +105,11 @@ class HookArmTool:
 
     # ---------------- control
     def start(self):
-        self.active = True
+        super().start()
         self.base = None
 
     def cancel(self):
-        self.active = False
+        super().cancel()
         self.dragging = False
 
     # ---------------- drawing helpers
@@ -127,7 +126,7 @@ class HookArmTool:
         return pts
 
     def draw_ui(self):
-        if not self.active or not self.sidebar.visible:
+        if not super().draw_ui():
             return
         self.seg_field.draw(self.sidebar.screen)
         self.space_field.draw(self.sidebar.screen)
@@ -145,7 +144,7 @@ class HookArmTool:
         self.sidebar.screen.blit(txt, rect)
 
     def draw_preview(self):
-        if not self.active or not self.base:
+        if not super().draw_preview() or not self.base:
             return
         screen = self.sidebar.screen
         color = (150, 150, 150)
@@ -157,7 +156,7 @@ class HookArmTool:
 
     # ---------------- event handling
     def handle_event(self, event):
-        if not self.active:
+        if not super().handle_event(event):
             return False
 
         if self.sidebar.visible:

--- a/builder_ui/tools/inspect_tool.py
+++ b/builder_ui/tools/inspect_tool.py
@@ -4,15 +4,14 @@ import math
 import pygame
 
 from ..fields import SliderField, ColorField
+from .base import Tool
 
 
-class InspectTool:
+class InspectTool(Tool):
     """Select a particle or spring and edit its properties from the sidebar."""
 
     def __init__(self, sidebar: 'SidebarUI'):
-        self.sidebar = sidebar
-        self.app = sidebar.app
-        self.active = False
+        super().__init__(sidebar)
         self.particle = None
         self.spring = None
         self.bend = None
@@ -120,19 +119,19 @@ class InspectTool:
 
     # ---------------- control
     def start(self):
-        self.active = True
+        super().start()
         self.particle = None
         self.spring = None
         self.bend = None
 
     def cancel(self):
-        self.active = False
+        super().cancel()
         self.particle = None
         self.spring = None
         self.bend = None
 
     def draw_ui(self):
-        if not self.active or not self.sidebar.visible:
+        if not super().draw_ui():
             return
         if self.particle:
             self.color_field.draw(self.sidebar.screen)
@@ -153,7 +152,7 @@ class InspectTool:
             self.bstiff_field.draw(self.sidebar.screen)
 
     def draw_preview(self):
-        if not self.active:
+        if not super().draw_preview():
             return
         if self.particle:
             pygame.draw.circle(
@@ -189,7 +188,7 @@ class InspectTool:
 
     # ---------------- event handling
     def handle_event(self, event):
-        if not self.active:
+        if not super().handle_event(event):
             return False
 
         if self.sidebar.visible:

--- a/builder_ui/tools/particle_tool.py
+++ b/builder_ui/tools/particle_tool.py
@@ -3,15 +3,14 @@
 import pygame
 
 from ..fields import SliderField, ColorField
+from .base import Tool
 
 
-class ParticleTool:
+class ParticleTool(Tool):
     """Handle options for creating new particles."""
 
     def __init__(self, sidebar: 'SidebarUI'):
-        self.sidebar = sidebar
-        self.app = sidebar.app
-        self.active = False
+        super().__init__(sidebar)
 
         x = sidebar.screen.get_width() - sidebar.WIDTH + 10
         width = sidebar.WIDTH - 20
@@ -29,27 +28,17 @@ class ParticleTool:
             "Radius", 1, 50, lambda: self.app.radius, self.app.set_radius, x, y, width
         )
 
-    # ---------------- control
-    def start(self):
-        self.active = True
-
-    def cancel(self):
-        self.active = False
-
     # ---------------- drawing
     def draw_ui(self):
-        if not self.active or not self.sidebar.visible:
+        if not super().draw_ui():
             return
         self.color_field.draw(self.sidebar.screen)
         self.mass_field.draw(self.sidebar.screen)
         self.radius_field.draw(self.sidebar.screen)
 
-    def draw_preview(self):
-        pass
-
     # ---------------- event handling
     def handle_event(self, event):
-        if not self.active:
+        if not super().handle_event(event):
             return False
         if self.sidebar.visible:
             if self.color_field.handle_event(event):

--- a/builder_ui/tools/rod_tool.py
+++ b/builder_ui/tools/rod_tool.py
@@ -4,15 +4,14 @@ import math
 import pygame
 
 from ..fields import SliderField
+from .base import Tool
 
 
-class RodTool:
+class RodTool(Tool):
     """Handle rod preview creation with sliders and click placement."""
 
     def __init__(self, sidebar: 'SidebarUI'):
-        self.sidebar = sidebar
-        self.app = sidebar.app
-        self.active = False
+        super().__init__(sidebar)
         self.center = None
         self.radius = 30.0
         self.length = 100.0
@@ -82,11 +81,11 @@ class RodTool:
 
     # ---------------- control
     def start(self):
-        self.active = True
+        super().start()
         self.center = None
 
     def cancel(self):
-        self.active = False
+        super().cancel()
         self.dragging = False
 
     # ---------------- helpers
@@ -121,7 +120,7 @@ class RodTool:
 
     # ---------------- drawing
     def draw_ui(self):
-        if not self.active or not self.sidebar.visible:
+        if not super().draw_ui():
             return
         self.radius_field.draw(self.sidebar.screen)
         self.length_field.draw(self.sidebar.screen)
@@ -152,7 +151,7 @@ class RodTool:
 
     def draw_preview(self):
         """Draw the rod preview at the current mouse position."""
-        if not self.active or self.center is None:
+        if not super().draw_preview() or self.center is None:
             return
 
         screen = self.sidebar.screen
@@ -222,7 +221,7 @@ class RodTool:
 
     # ---------------- event handling
     def handle_event(self, event):
-        if not self.active:
+        if not super().handle_event(event):
             return False
 
         if self.sidebar.visible:
@@ -242,7 +241,6 @@ class RodTool:
                 if self.bend_rect.collidepoint(event.pos):
                     self.include_bend = not self.include_bend
                     return True
-            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
                 if self.cyto_rect.collidepoint(event.pos):
                     self.include_cytoskeleton = not self.include_cytoskeleton
                     return True

--- a/builder_ui/tools/spring_tool.py
+++ b/builder_ui/tools/spring_tool.py
@@ -3,15 +3,14 @@
 import pygame
 
 from ..fields import SliderField
+from .base import Tool
 
 
-class SpringTool:
+class SpringTool(Tool):
     """Handle spring stiffness options when creating new springs."""
 
     def __init__(self, sidebar: 'SidebarUI'):
-        self.sidebar = sidebar
-        self.app = sidebar.app
-        self.active = False
+        super().__init__(sidebar)
 
         x = sidebar.screen.get_width() - sidebar.WIDTH + 10
         width = sidebar.WIDTH - 20
@@ -21,25 +20,15 @@ class SpringTool:
             "Stiff", 10, 1000, lambda: self.app.stiffness, self.app.set_stiffness, x, y, width
         )
 
-    # ---------------- control
-    def start(self):
-        self.active = True
-
-    def cancel(self):
-        self.active = False
-
     # ---------------- drawing
     def draw_ui(self):
-        if not self.active or not self.sidebar.visible:
+        if not super().draw_ui():
             return
         self.stiff_field.draw(self.sidebar.screen)
 
-    def draw_preview(self):
-        pass
-
     # ---------------- event handling
     def handle_event(self, event):
-        if not self.active:
+        if not super().handle_event(event):
             return False
         if self.sidebar.visible:
             if self.stiff_field.handle_event(event):


### PR DESCRIPTION
## Summary
- add a `Tool` base class providing default start/cancel hooks and no-op drawing/event helpers
- refactor builder tools to inherit from `Tool` and drop duplicate lifecycle code
- document the new base class in README and AGENTS

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `SDL_VIDEODRIVER=dummy python start_basic.py`

------
https://chatgpt.com/codex/tasks/task_e_688e879e54a88325a6e6e5215f116451