### PR TITLE
refactor builder state io

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repository contains small pygame demos for 2D particle-based physics simula
 - `builder_ui/` – sidebar UI widgets used by the interactive builder.
 - `color_picker.py` – colour picker helper using Tkinter.
 - `file_dialog.py` – opens save/load dialogs in a separate process.
+- `builder_io.py` – helper functions to save or load builder scenes.
 - `start_create.py` – interactive builder for constructing scenes.
 - `start.py` – demo of a soft cell made from three circular walls.
 - `start_basic.py` – minimal ring of particles demo.
@@ -59,6 +60,7 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - Builder sidebar now has **Save** and **Load** buttons for exporting and
   importing scene states.
 - Loading a saved scene now refreshes the physics engine so simulations resume.
+- Save/load logic now lives in a new ``builder_io`` module.
 - Circle and rod tools now expose spring stiffness sliders and can add bending springs along their outline.
 - A new **Grid** tool can overlay a configurable grid; enabling it snaps new particles to the nearest intersection.
 - Sidebar includes an **Undo** button to revert the most recent change.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
   * `builder_ui/` and `color_picker.py` – the sidebar widgets and the cross‑platform colour selection utility. Tools in this
     package inherit from a small :class:`Tool` base class that provides
     default lifecycle, drawing and event hooks.
+  * `builder_io.py` – save/load helpers for the interactive builder.
   * **High-drag adhesion** – set a particle's ``tag`` to ``"high_drag"`` and the
     physics engine multiplies its viscous drag, causing it to stick in place.
   * **Weighted adhesion** – a ``HookArm`` tip also increases in mass when stuck

--- a/builder_io.py
+++ b/builder_io.py
@@ -1,0 +1,33 @@
+"""Helper functions for saving and loading builder scenes."""
+
+from __future__ import annotations
+
+import json
+from file_dialog import choose_open_path, choose_save_path
+
+
+def save_state(path: str, state: dict) -> None:
+    """Write *state* to *path* as JSON."""
+    with open(path, "w") as fh:
+        json.dump(state, fh, indent=2)
+
+
+def load_state(path: str) -> dict:
+    """Return scene state loaded from *path*."""
+    with open(path, "r") as fh:
+        return json.load(fh)
+
+
+def save_state_dialog(state: dict) -> None:
+    """Prompt for a path and save *state* if one is chosen."""
+    path = choose_save_path("scene.json")
+    if path:
+        save_state(path, state)
+
+
+def load_state_dialog() -> dict | None:
+    """Prompt for a path and return the loaded scene state."""
+    path = choose_open_path()
+    if path:
+        return load_state(path)
+    return None

--- a/start_create.py
+++ b/start_create.py
@@ -1,6 +1,5 @@
 import pygame
 import math
-import json
 from typing import Callable
 
 from particle import Particle
@@ -14,7 +13,7 @@ from builder_ui.config import (
     SpringParams,
     EnvironmentParams,
 )
-from file_dialog import choose_save_path, choose_open_path
+import builder_io
 from structures import create_rod as structure_create_rod
 from hook_arm import HookArm
 
@@ -230,17 +229,18 @@ class BuilderApp:
 
     # ------------------------------------------------------------------ save/load
     def save_state_dialog(self):
-        path = choose_save_path("scene.json")
-        if path:
-            self.save_state(path)
+        """Export the current scene through a save dialog."""
+        builder_io.save_state_dialog(self._build_state())
 
     def load_state_dialog(self):
-        path = choose_open_path()
-        if path:
-            self.load_state(path)
+        """Import a scene from a chosen file path."""
+        data = builder_io.load_state_dialog()
+        if data:
+            self._apply_state(data)
 
-    def save_state(self, path: str):
-        data = {
+    def _build_state(self) -> dict:
+        """Return a serialisable representation of the scene."""
+        return {
             "particles": [
                 {
                     "pos": [p.pos.x, p.pos.y],
@@ -297,13 +297,9 @@ class BuilderApp:
                 "damping_coeff": self.physics.damping_coeff,
             },
         }
-        with open(path, "w") as fh:
-            json.dump(data, fh, indent=2)
 
-    def load_state(self, path: str):
-        with open(path, "r") as fh:
-            data = json.load(fh)
-
+    def _apply_state(self, data: dict) -> None:
+        """Rebuild the scene from a serialised *data* structure."""
         self.particles = []
         for pd in data.get("particles", []):
             p = Particle(


### PR DESCRIPTION
## Summary
- extract save/load helpers into new `builder_io.py` with dialog wrappers
- delegate builder save/load through `builder_io` and add state build/apply helpers
- document new module in README and AGENTS

## Testing
- `python -m py_compile builder_io.py start_create.py`


------
https://chatgpt.com/codex/tasks/task_e_688fbf8991dc8325bae55669ae6a8bef