### PR TITLE
Document builder tools and creation script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,4 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
 - Particle, spring and environment parameters now reside in ``builder_ui/config.py``
   dataclasses, and the builder updates these structures directly instead of
   using individual setter methods.
+- Comprehensive docstrings added across builder tools and the main builder app.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
     for extra grip.
   * **Adjustable springs** – spring rest lengths can be changed on the fly to
     mimic contracting or extending structures.
+  * **Developer-friendly** – comprehensive docstrings document the builder UI
+    and creation script.
 
 ### Using high-drag particles
 

--- a/builder_ui/fields.py
+++ b/builder_ui/fields.py
@@ -10,6 +10,22 @@ class SliderField:
     BOX_WIDTH = 50
 
     def __init__(self, label, min_val, max_val, get_value, set_value, x, y, width):
+        """Initialise a new slider widget.
+
+        Parameters
+        ----------
+        label:
+            Text label displayed above the slider.
+        min_val, max_val:
+            Range of selectable values.
+        get_value:
+            Callable returning the current value.
+        set_value:
+            Callable used to update the value.
+        x, y, width:
+            Position and width of the slider in pixels.
+        """
+
         self.label = label
         self.min = min_val
         self.max = max_val
@@ -26,12 +42,50 @@ class SliderField:
         self.text = ""
 
     def _value_to_ratio(self, value):
+        """Map ``value`` onto the 0–1 slider range.
+
+        Parameters
+        ----------
+        value:
+            Value within ``[self.min, self.max]``.
+
+        Returns
+        -------
+        float
+            Normalised ratio representing the slider position.
+        """
+
         return max(0, min(1, (value - self.min) / (self.max - self.min)))
 
     def _ratio_to_value(self, ratio):
+        """Convert a slider ratio back into a value.
+
+        Parameters
+        ----------
+        ratio:
+            Normalised position between 0 and 1.
+
+        Returns
+        -------
+        float
+            Value corresponding to ``ratio``.
+        """
+
         return self.min + ratio * (self.max - self.min)
 
     def draw(self, screen):
+        """Render the slider and its numeric field.
+
+        Parameters
+        ----------
+        screen:
+            Surface on which to draw.
+
+        Returns
+        -------
+        None
+        """
+
         value = self.get_value()
         # label
         lbl = self.font.render(self.label, True, (255, 255, 255))
@@ -50,6 +104,19 @@ class SliderField:
         screen.blit(img, rect)
 
     def handle_event(self, event):
+        """Process input events for the slider.
+
+        Parameters
+        ----------
+        event:
+            Pygame event to handle.
+
+        Returns
+        -------
+        bool
+            ``True`` if the event was consumed.
+        """
+
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             if self.slider_rect.collidepoint(event.pos):
                 self.dragging = True
@@ -85,6 +152,18 @@ class SliderField:
         return False
 
     def _update_value(self, mouse_x):
+        """Update the stored value from the mouse position.
+
+        Parameters
+        ----------
+        mouse_x:
+            Horizontal mouse coordinate in pixels.
+
+        Returns
+        -------
+        None
+        """
+
         ratio = (mouse_x - self.slider_rect.x) / self.slider_rect.width
         ratio = max(0, min(1, ratio))
         self.set_value(self._ratio_to_value(ratio))
@@ -97,6 +176,18 @@ class ColorField:
     COLOR_SIZE = 24
 
     def __init__(self, label, get_color, set_color, x, y, width):
+        """Initialise a colour selection field.
+
+        Parameters
+        ----------
+        label:
+            Text displayed above the field.
+        get_color, set_color:
+            Callables for retrieving and storing the colour.
+        x, y, width:
+            Position and width in pixels.
+        """
+
         self.label = label
         self.get_color = get_color
         self.set_color = set_color
@@ -111,6 +202,18 @@ class ColorField:
         self.text = ""
 
     def draw(self, screen):
+        """Render the colour swatch and hex entry box.
+
+        Parameters
+        ----------
+        screen:
+            Surface on which to draw.
+
+        Returns
+        -------
+        None
+        """
+
         color = self.get_color()
         lbl = self.font.render(self.label, True, (255, 255, 255))
         screen.blit(lbl, (self.color_rect.x, self.color_rect.y - 18))
@@ -125,6 +228,19 @@ class ColorField:
         screen.blit(img, rect)
 
     def handle_event(self, event):
+        """Process user input for the colour field.
+
+        Parameters
+        ----------
+        event:
+            Pygame event to handle.
+
+        Returns
+        -------
+        bool
+            ``True`` if the event was consumed.
+        """
+
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             if self.color_rect.collidepoint(event.pos):
                 self._choose_color()
@@ -155,6 +271,18 @@ class ColorField:
             self.set_color(rgb)
 
     def _set_color_hex(self, value: str):
+        """Parse ``value`` as ``#RRGGBB`` and update the colour.
+
+        Parameters
+        ----------
+        value:
+            Hexadecimal colour string.
+
+        Returns
+        -------
+        None
+        """
+
         value = value.lstrip("#")
         if len(value) != 6:
             return
@@ -173,6 +301,18 @@ class KeyField:
     BOX_WIDTH = 60
 
     def __init__(self, label, get_key, set_key, x, y, width):
+        """Create an editable key field.
+
+        Parameters
+        ----------
+        label:
+            Text displayed above the field.
+        get_key, set_key:
+            Callables for retrieving and storing the key.
+        x, y, width:
+            Position and width in pixels.
+        """
+
         self.label = label
         self.get_key = get_key
         self.set_key = set_key
@@ -182,6 +322,18 @@ class KeyField:
         self.editing = False
 
     def draw(self, screen):
+        """Render the key field.
+
+        Parameters
+        ----------
+        screen:
+            Surface on which to draw.
+
+        Returns
+        -------
+        None
+        """
+
         key = self.get_key()
         text = pygame.key.name(key) if key is not None else "None"
         if self.editing:
@@ -195,6 +347,19 @@ class KeyField:
         screen.blit(img, rect)
 
     def handle_event(self, event):
+        """Handle mouse and keyboard input.
+
+        Parameters
+        ----------
+        event:
+            Pygame event to process.
+
+        Returns
+        -------
+        bool
+            ``True`` if the event was consumed.
+        """
+
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             if self.box_rect.collidepoint(event.pos):
                 self.editing = True

--- a/builder_ui/sidebar.py
+++ b/builder_ui/sidebar.py
@@ -20,6 +20,16 @@ class SidebarUI:
     TOGGLE_SIZE = 20
 
     def __init__(self, screen: pygame.Surface, app):
+        """Create the sidebar UI and all tool instances.
+
+        Parameters
+        ----------
+        screen:
+            Surface used for rendering.
+        app:
+            Owning :class:`~start_create.BuilderApp`.
+        """
+
         self.screen = screen
         self.app = app
         self.font = pygame.font.SysFont(None, 24)
@@ -41,6 +51,8 @@ class SidebarUI:
 
     # ----------------------------------------------------------- setup
     def _setup_ui(self):
+        """Create default buttons and compute layout offsets."""
+
         sw = self.screen.get_width()
         x = sw - self.WIDTH + 10
         y = 10
@@ -71,10 +83,12 @@ class SidebarUI:
         self.extra_start_y = y
 
     def visible_width(self):
+        """Return the width of the sidebar when visible."""
         return self.WIDTH if self.visible else 0
 
     # ----------------------------------------------------------- draw
     def draw(self):
+        """Render the sidebar and active tool interfaces."""
         sw = self.screen.get_width()
         sidebar_rect = pygame.Rect(sw - self.visible_width(), 0, self.visible_width(), self.screen.get_height())
         toggle_x = sw - self.visible_width() - self.TOGGLE_SIZE
@@ -125,6 +139,19 @@ class SidebarUI:
 
     # ----------------------------------------------------------- event handler
     def handle_event(self, event):
+        """Forward events to the sidebar and active tools.
+
+        Parameters
+        ----------
+        event:
+            Pygame event to process.
+
+        Returns
+        -------
+        bool
+            ``True`` if the event was consumed.
+        """
+
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             if self.toggle_rect.collidepoint(event.pos):
                 self.visible = not self.visible

--- a/builder_ui/tools/bending_spring_tool.py
+++ b/builder_ui/tools/bending_spring_tool.py
@@ -12,6 +12,8 @@ class BendingSpringTool(Tool):
     """Create a bending spring by choosing three particles."""
 
     def __init__(self, sidebar: 'SidebarUI'):
+        """Configure fields for creating bending springs."""
+
         super().__init__(sidebar)
         self.angle = 90.0
         self.stiffness = 200.0
@@ -35,23 +37,28 @@ class BendingSpringTool(Tool):
         self.create_rect = pygame.Rect(x, y, width, self.sidebar.BUTTON_HEIGHT)
 
     def _set_angle(self, val: float):
+        """Set the manual bend angle in degrees."""
         self.angle = max(0, val)
 
     def _set_stiff(self, val: float):
+        """Set stiffness for the new bending spring."""
         self.stiffness = max(10, val)
 
     # ---------------- control
     def start(self):
+        """Activate the tool and clear previous selections."""
         super().start()
         self.auto_angle = False
         self.selected.clear()
 
     def cancel(self):
+        """Deactivate the tool and forget current selections."""
         super().cancel()
         self.selected.clear()
 
     # ---------------- drawing
     def draw_ui(self):
+        """Render bending spring configuration controls."""
         if not super().draw_ui():
             return
         if not self.auto_angle:
@@ -68,6 +75,7 @@ class BendingSpringTool(Tool):
         self.sidebar.screen.blit(txt, rect)
 
     def draw_preview(self):
+        """Highlight selected particles and preview links."""
         if not super().draw_preview():
             return
         screen = self.sidebar.screen
@@ -81,6 +89,7 @@ class BendingSpringTool(Tool):
 
     # ---------------- event handling
     def handle_event(self, event):
+        """Handle field input and particle selection."""
         if not super().handle_event(event):
             return False
 

--- a/builder_ui/tools/circle_tool.py
+++ b/builder_ui/tools/circle_tool.py
@@ -11,6 +11,8 @@ class CircleTool(Tool):
     """Handle circle preview creation with sliders and dragging."""
 
     def __init__(self, sidebar: 'SidebarUI'):
+        """Configure sliders and defaults for circle creation."""
+
         super().__init__(sidebar)
         self.center = None
         self.radius = 50.0
@@ -46,19 +48,24 @@ class CircleTool(Tool):
 
     # ---------------- value setters
     def _set_radius(self, value: float):
+        """Update preview radius."""
         self.radius = max(1, value)
 
     def _set_segments(self, value: float):
+        """Set number of circle segments."""
         self.segments = max(3, int(value))
 
     def _set_stiff(self, value: float):
+        """Set spring stiffness for new circles."""
         self.stiffness = max(10, value)
 
     def _set_bstiff(self, value: float):
+        """Set bending spring stiffness."""
         self.bend_stiffness = max(10, value)
 
     # ---------------- control
     def start(self):
+        """Begin circle placement and reset parameters."""
         super().start()
         self.center = None
         self.stiffness = self.app.spring.stiffness
@@ -66,10 +73,12 @@ class CircleTool(Tool):
         self.include_bend = False
 
     def cancel(self):
+        """Abort circle creation."""
         super().cancel()
         self.dragging = False
 
     def draw_ui(self):
+        """Render circle creation controls."""
         if not super().draw_ui():
             return
         self.radius_field.draw(self.sidebar.screen)
@@ -88,6 +97,7 @@ class CircleTool(Tool):
         self.sidebar.screen.blit(txt, rect)
 
     def draw_preview(self):
+        """Draw a circle preview at the current mouse position."""
         if not super().draw_preview() or self.center is None:
             return
         screen = self.sidebar.screen
@@ -114,6 +124,7 @@ class CircleTool(Tool):
 
     # ---------------- event handling
     def handle_event(self, event):
+        """Handle mouse input for circle placement and UI controls."""
         if not super().handle_event(event):
             return False
 

--- a/builder_ui/tools/environment_tool.py
+++ b/builder_ui/tools/environment_tool.py
@@ -10,6 +10,8 @@ class EnvironmentTool(Tool):
     """Expose global simulation options such as gravity and temperature."""
 
     def __init__(self, sidebar: 'SidebarUI'):
+        """Build sliders for global simulation parameters."""
+
         super().__init__(sidebar)
 
         x = sidebar.screen.get_width() - sidebar.WIDTH + 10
@@ -84,35 +86,42 @@ class EnvironmentTool(Tool):
 
     # ---------------- value setters
     def _set_gravity_x(self, value: float):
+        """Set horizontal gravity component."""
         self.app.environment.gravity.x = value
         self.app.physics.gravity.x = value
 
     def _set_gravity_y(self, value: float):
+        """Set vertical gravity component."""
         self.app.environment.gravity.y = value
         self.app.physics.gravity.y = value
 
     def _set_repulsion_radius(self, value: float):
+        """Update radius for particle repulsion."""
         val = max(0, value)
         self.app.environment.repulsion_radius = val
         self.app.physics.repulsion_radius = val
 
     def _set_repulsion_strength(self, value: float):
+        """Update magnitude of particle repulsion."""
         val = max(0, value)
         self.app.environment.repulsion_strength = val
         self.app.physics.repulsion_strength = val
 
     def _set_damping(self, value: float):
+        """Adjust global viscous damping."""
         val = max(0, value)
         self.app.environment.damping = val
         self.app.physics.damping_coeff = val
 
     def _set_temperature(self, value: float):
+        """Set Brownian motion intensity."""
         val = max(0, value)
         self.app.environment.temperature = val
         self.app.physics.temperature = val
 
     # ---------------- drawing
     def draw_ui(self):
+        """Render sliders for environment parameters."""
         if not super().draw_ui():
             return
         self.gx_field.draw(self.sidebar.screen)
@@ -124,6 +133,7 @@ class EnvironmentTool(Tool):
 
     # ---------------- event handling
     def handle_event(self, event):
+        """Forward events to environment sliders."""
         if not super().handle_event(event):
             return False
         if self.sidebar.visible:

--- a/builder_ui/tools/grid_tool.py
+++ b/builder_ui/tools/grid_tool.py
@@ -10,6 +10,8 @@ class GridTool(Tool):
     """Toggle a grid overlay and adjust its spacing."""
 
     def __init__(self, sidebar: 'SidebarUI'):
+        """Create widgets for toggling the grid and adjusting spacing."""
+
         super().__init__(sidebar)
 
         x = sidebar.screen.get_width() - sidebar.WIDTH + 10
@@ -24,6 +26,7 @@ class GridTool(Tool):
 
     # ---------------- drawing
     def draw_ui(self):
+        """Render the grid toggle and spacing slider."""
         if not super().draw_ui():
             return
         pygame.draw.rect(self.sidebar.screen, (80, 80, 80), self.toggle_rect)
@@ -35,6 +38,7 @@ class GridTool(Tool):
 
     # ---------------- event handling
     def handle_event(self, event):
+        """Handle mouse input for grid toggling and spacing."""
         if not super().handle_event(event):
             return False
         if self.sidebar.visible:

--- a/builder_ui/tools/hook_arm_tool.py
+++ b/builder_ui/tools/hook_arm_tool.py
@@ -15,6 +15,8 @@ class HookArmTool(Tool):
     """
 
     def __init__(self, sidebar: 'SidebarUI'):
+        """Setup controls for building hook arms."""
+
         super().__init__(sidebar)
         self.base = None
         self.direction = pygame.Vector2(1, 0)
@@ -74,46 +76,59 @@ class HookArmTool(Tool):
 
     # ---------------- value setters
     def _set_segments(self, value: float):
+        """Set number of arm segments."""
         self.segments = max(1, int(value))
 
     def _set_spacing(self, value: float):
+        """Set spacing between arm particles."""
         self.spacing = max(1, value)
 
     def _set_mass(self, value: float):
+        """Set particle mass for the arm."""
         self.mass = max(0.1, value)
 
     def _set_radius(self, value: float):
+        """Set particle radius for the arm."""
         self.radius = max(1, value)
 
     def _set_stiffness(self, value: float):
+        """Set spring stiffness along the arm."""
         self.stiffness = max(10, value)
 
     def _set_speed(self, value: float):
+        """Set cycle speed for automatic motion."""
         self.cycle_speed = max(10, value)
 
     def _set_color(self, color):
+        """Set default arm colour."""
         self.color = color
 
     def _set_high_color(self, color):
+        """Set colour used when high drag is active."""
         self.high_drag_color = color
 
     def _set_adhesion(self, value: float):
+        """Set mass multiplier applied during adhesion."""
         self.adhesion_factor = max(1, value)
 
     def _set_key(self, value: int | None):
+        """Set keyboard key used to cycle the arm."""
         self.cycle_key = value
 
     # ---------------- control
     def start(self):
+        """Activate the tool and clear base particle."""
         super().start()
         self.base = None
 
     def cancel(self):
+        """Deactivate the tool and stop dragging preview."""
         super().cancel()
         self.dragging = False
 
     # ---------------- drawing helpers
     def _preview_points(self):
+        """Compute points for the arm preview."""
         if not self.base:
             return []
         if self.direction.length() == 0:
@@ -126,6 +141,7 @@ class HookArmTool(Tool):
         return pts
 
     def draw_ui(self):
+        """Render hook arm configuration controls."""
         if not super().draw_ui():
             return
         self.seg_field.draw(self.sidebar.screen)
@@ -144,6 +160,7 @@ class HookArmTool(Tool):
         self.sidebar.screen.blit(txt, rect)
 
     def draw_preview(self):
+        """Draw a preview of the prospective arm."""
         if not super().draw_preview() or not self.base:
             return
         screen = self.sidebar.screen
@@ -156,6 +173,7 @@ class HookArmTool(Tool):
 
     # ---------------- event handling
     def handle_event(self, event):
+        """Manage UI interaction and base selection."""
         if not super().handle_event(event):
             return False
 

--- a/builder_ui/tools/inspect_tool.py
+++ b/builder_ui/tools/inspect_tool.py
@@ -11,6 +11,8 @@ class InspectTool(Tool):
     """Select a particle or spring and edit its properties from the sidebar."""
 
     def __init__(self, sidebar: 'SidebarUI'):
+        """Prepare fields for inspecting particles, springs and bends."""
+
         super().__init__(sidebar)
         self.particle = None
         self.spring = None
@@ -56,81 +58,101 @@ class InspectTool(Tool):
 
     # ---------------- helpers
     def _get_color(self):
+        """Return the selected particle colour or white."""
         return self.particle.color if self.particle else (255, 255, 255)
 
     def _set_color(self, color):
+        """Update the selected particle colour."""
         if self.particle:
             self.particle.color = color
 
     def _get_mass(self):
+        """Return selected particle mass."""
         return self.particle.mass if self.particle else 0
 
     def _set_mass(self, value: float):
+        """Set selected particle mass."""
         if self.particle:
             self.particle.mass = max(0.1, value)
 
     def _get_radius(self):
+        """Return selected particle radius."""
         return self.particle.radius if self.particle else 0
 
     def _set_radius(self, value: float):
+        """Set selected particle radius."""
         if self.particle:
             self.particle.radius = max(1, int(value))
 
     def _get_rest(self):
+        """Return spring rest length."""
         return self.spring.rest_length if self.spring else 0
 
     def _set_rest(self, value: float):
+        """Update spring rest length."""
         if self.spring:
             self.spring.rest_length = max(1, value)
 
     def _get_stiff(self):
+        """Return spring stiffness."""
         return self.spring.stiffness if self.spring else 0
 
     def _set_stiff(self, value: float):
+        """Set spring stiffness."""
         if self.spring:
             self.spring.stiffness = max(10, value)
 
     def _get_bangle(self):
+        """Return bend rest angle in degrees."""
         return math.degrees(self.bend.rest_angle) if self.bend else 0
 
     def _set_bangle(self, value: float):
+        """Set bend rest angle in degrees."""
         if self.bend:
             self.bend.rest_angle = math.radians(max(0, value))
 
     def _get_bstiff(self):
+        """Return bend stiffness."""
         return self.bend.stiffness if self.bend else 0
 
     def _set_bstiff(self, value: float):
+        """Set bend stiffness."""
         if self.bend:
             self.bend.stiffness = max(10, value)
 
     def _get_max(self):
+        """Return spring max force or ``0`` if unlimited."""
         if not self.spring:
             return 0
         return self.spring.max_force if self.spring.max_force is not None else 0
 
     def _set_max(self, value: float):
+        """Set spring max force, using ``None`` for no limit."""
         if self.spring:
             self.spring.max_force = None if value == 0 else value
 
     def _toggle_invisible(self):
+        """Toggle visibility of the selected spring."""
         if self.spring:
             self.spring.invisible = not self.spring.invisible
 
     # ---------------- control
     def start(self):
+        """Activate the tool and clear previous selection."""
         super().start()
         self.particle = None
         self.spring = None
         self.bend = None
 
     def cancel(self):
+        """Deactivate the tool and clear selection."""
         super().cancel()
         self.particle = None
         self.spring = None
         self.bend = None
 
     def draw_ui(self):
+        """Render fields for the currently selected object."""
         if not super().draw_ui():
             return
         if self.particle:
@@ -152,6 +174,7 @@ class InspectTool(Tool):
             self.bstiff_field.draw(self.sidebar.screen)
 
     def draw_preview(self):
+        """Highlight the currently selected object."""
         if not super().draw_preview():
             return
         if self.particle:
@@ -188,6 +211,7 @@ class InspectTool(Tool):
 
     # ---------------- event handling
     def handle_event(self, event):
+        """Process selection and slider events."""
         if not super().handle_event(event):
             return False
 

--- a/builder_ui/tools/particle_tool.py
+++ b/builder_ui/tools/particle_tool.py
@@ -10,6 +10,8 @@ class ParticleTool(Tool):
     """Handle options for creating new particles."""
 
     def __init__(self, sidebar: 'SidebarUI'):
+        """Initialise sliders controlling new particle properties."""
+
         super().__init__(sidebar)
 
         x = sidebar.screen.get_width() - sidebar.WIDTH + 10
@@ -49,6 +51,7 @@ class ParticleTool(Tool):
 
     # ---------------- drawing
     def draw_ui(self):
+        """Render particle configuration sliders."""
         if not super().draw_ui():
             return
         self.color_field.draw(self.sidebar.screen)
@@ -57,6 +60,7 @@ class ParticleTool(Tool):
 
     # ---------------- event handling
     def handle_event(self, event):
+        """Forward input events to particle option widgets."""
         if not super().handle_event(event):
             return False
         if self.sidebar.visible:

--- a/builder_ui/tools/rod_tool.py
+++ b/builder_ui/tools/rod_tool.py
@@ -11,6 +11,8 @@ class RodTool(Tool):
     """Handle rod preview creation with sliders and click placement."""
 
     def __init__(self, sidebar: 'SidebarUI'):
+        """Prepare UI elements for rod creation."""
+
         super().__init__(sidebar)
         self.center = None
         self.radius = 30.0
@@ -62,34 +64,43 @@ class RodTool(Tool):
 
     # ---------------- value setters
     def _set_radius(self, value: float):
+        """Set rod radius."""
         self.radius = max(1, value)
 
     def _set_length(self, value: float):
+        """Set rod length."""
         self.length = max(1, value)
 
     def _set_segments(self, value: float):
+        """Set number of perimeter particles."""
         self.segments = max(4, int(value))
 
     def _set_skel_count(self, value: float):
+        """Set number of skeleton nodes."""
         self.skeleton_count = max(1, int(value))
 
     def _set_stiff(self, value: float):
+        """Set spring stiffness for rods."""
         self.stiffness = max(10, value)
 
     def _set_bstiff(self, value: float):
+        """Set bending spring stiffness."""
         self.bend_stiffness = max(10, value)
 
     # ---------------- control
     def start(self):
+        """Activate the tool and reset the center."""
         super().start()
         self.center = None
 
     def cancel(self):
+        """Deactivate the tool and stop dragging."""
         super().cancel()
         self.dragging = False
 
     # ---------------- helpers
     def _generate_points(self):
+        """Return perimeter points for the current rod preview."""
         center = self.center
         if center is None:
             return []
@@ -120,6 +131,7 @@ class RodTool(Tool):
 
     # ---------------- drawing
     def draw_ui(self):
+        """Render rod configuration controls."""
         if not super().draw_ui():
             return
         self.radius_field.draw(self.sidebar.screen)
@@ -233,6 +245,7 @@ class RodTool(Tool):
 
     # ---------------- event handling
     def handle_event(self, event):
+        """Process mouse input for rod placement and option toggles."""
         if not super().handle_event(event):
             return False
 

--- a/builder_ui/tools/spring_tool.py
+++ b/builder_ui/tools/spring_tool.py
@@ -10,6 +10,8 @@ class SpringTool(Tool):
     """Handle spring stiffness options when creating new springs."""
 
     def __init__(self, sidebar: 'SidebarUI'):
+        """Create the stiffness slider for new springs."""
+
         super().__init__(sidebar)
 
         x = sidebar.screen.get_width() - sidebar.WIDTH + 10
@@ -29,12 +31,14 @@ class SpringTool(Tool):
 
     # ---------------- drawing
     def draw_ui(self):
+        """Render the spring stiffness slider."""
         if not super().draw_ui():
             return
         self.stiff_field.draw(self.sidebar.screen)
 
     # ---------------- event handling
     def handle_event(self, event):
+        """Forward input events to the stiffness slider."""
         if not super().handle_event(event):
             return False
         if self.sidebar.visible:

--- a/start_create.py
+++ b/start_create.py
@@ -24,6 +24,8 @@ FPS = 120
 class BuilderApp:
     """Main application class for the particle builder demo."""
     def __init__(self):
+        """Initialise pygame, state containers and helper objects."""
+
         pygame.init()
         self.screen = pygame.display.set_mode(SCREEN_SIZE)
         pygame.display.set_caption("Particle Builder")
@@ -68,6 +70,7 @@ class BuilderApp:
 
     # ------------------------------------------------------------------ parameter helpers
     def set_mode(self, mode: str):
+        """Switch the active builder mode and notify tools."""
         if self.mode == "circle" and mode != "circle":
             self.ui.circle_tool.cancel()
         if self.mode == "rod" and mode != "rod":
@@ -121,19 +124,24 @@ class BuilderApp:
             self.particle.color = rgb
 
     def adjust_mass(self, delta: float):
+        """Increment particle mass by ``delta``."""
         self.particle.mass = max(0.1, self.particle.mass + delta)
 
     def adjust_radius(self, delta: int):
+        """Increment particle radius by ``delta`` pixels."""
         self.particle.radius = max(1, self.particle.radius + delta)
 
     def adjust_stiffness(self, delta: float):
+        """Increment spring stiffness by ``delta``."""
         self.spring.stiffness = max(10, self.spring.stiffness + delta)
 
     def adjust_temperature(self, delta: float):
+        """Increment environment temperature by ``delta``."""
         self.environment.temperature = max(0, self.environment.temperature + delta)
         self.physics.temperature = self.environment.temperature
 
     def toggle_pause(self):
+        """Pause or resume the simulation."""
         self.paused = not self.paused
 
     def toggle_grid(self):
@@ -607,6 +615,7 @@ class BuilderApp:
 
     # ------------------------------------------------------------------ main
     def run(self):
+        """Main application loop."""
         running = True
         while running:
             dt = self.clock.tick(FPS) / 1000


### PR DESCRIPTION
## Summary
- Add detailed docstrings throughout sidebar fields and widgets
- Document builder tool methods, improving clarity of the UI code
- Cover builder application helpers with concise docstrings

## Testing
- `python -m py_compile builder_ui/fields.py builder_ui/sidebar.py builder_ui/tools/particle_tool.py builder_ui/tools/spring_tool.py builder_ui/tools/grid_tool.py builder_ui/tools/environment_tool.py builder_ui/tools/bending_spring_tool.py builder_ui/tools/rod_tool.py builder_ui/tools/inspect_tool.py builder_ui/tools/circle_tool.py builder_ui/tools/hook_arm_tool.py start_create.py`


------
https://chatgpt.com/codex/tasks/task_e_688fc1e08a808325ab0baadee53488bf