### PR TITLE
Centralise tool visibility checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,5 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
   dataclasses, and the builder updates these structures directly instead of
   using individual setter methods.
 - Comprehensive docstrings added across builder tools and the main builder app.
+- Tool base class now performs active/visibility checks in ``handle_event``,
+  removing duplicate logic from individual tools.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
   * `structures.py` – helper functions to build shapes like circular walls or rods.
   * `builder_ui/` and `color_picker.py` – the sidebar widgets and the cross‑platform colour selection utility. Tools in this
     package inherit from a small :class:`Tool` base class that provides
-    default lifecycle, drawing and event hooks.
+    default lifecycle, drawing and event hooks, including a shared
+    active/visibility check for event handling.
   * `builder_io.py` – save/load helpers for the interactive builder.
   * **High-drag adhesion** – set a particle's ``tag`` to ``"high_drag"`` and the
     physics engine multiplies its viscous drag, causing it to stick in place.

--- a/builder_ui/tools/base.py
+++ b/builder_ui/tools/base.py
@@ -63,7 +63,8 @@ class Tool:
             if not super().handle_event(event):
                 return False
 
-        The default simply checks ``self.active``.
+        The default method returns ``True`` only when the tool is active and the
+        sidebar is visible.
         """
 
-        return self.active
+        return self.active and getattr(self.sidebar, "visible", True)

--- a/builder_ui/tools/bending_spring_tool.py
+++ b/builder_ui/tools/bending_spring_tool.py
@@ -92,42 +92,40 @@ class BendingSpringTool(Tool):
         """Handle field input and particle selection."""
         if not super().handle_event(event):
             return False
-
-        if self.sidebar.visible:
-            if not self.auto_angle:
-                if self.angle_field.handle_event(event):
-                    return True
-            if self.stiff_field.handle_event(event):
+        if not self.auto_angle:
+            if self.angle_field.handle_event(event):
                 return True
-            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-                if self.auto_rect.collidepoint(event.pos):
-                    self.auto_angle = not self.auto_angle
-                    return True
-            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-                if self.create_rect.collidepoint(event.pos) and len(self.selected) == 3:
-                    from math import radians
-                    if self.auto_angle:
-                        v1 = self.selected[0].pos - self.selected[1].pos
-                        v2 = self.selected[2].pos - self.selected[1].pos
-                        if v1.length() == 0 or v2.length() == 0:
-                            angle = 0
-                        else:
-                            dot = max(-1.0, min(1.0, v1.dot(v2) / (v1.length()*v2.length())))
-                            angle = math.acos(dot)
+        if self.stiff_field.handle_event(event):
+            return True
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.auto_rect.collidepoint(event.pos):
+                self.auto_angle = not self.auto_angle
+                return True
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.create_rect.collidepoint(event.pos) and len(self.selected) == 3:
+                from math import radians
+                if self.auto_angle:
+                    v1 = self.selected[0].pos - self.selected[1].pos
+                    v2 = self.selected[2].pos - self.selected[1].pos
+                    if v1.length() == 0 or v2.length() == 0:
+                        angle = 0
                     else:
-                        angle = radians(self.angle)
-                    bs = BendingSpring(
-                        self.selected[0],
-                        self.selected[1],
-                        self.selected[2],
-                        angle,
-                        self.stiffness,
-                    )
-                    self.app.bending_springs.append(bs)
-                    self.app.push_undo(lambda bs=bs: self.app._remove_bending(bs))
-                    self.cancel()
-                    self.sidebar.app.set_mode("drag")
-                    return True
+                        dot = max(-1.0, min(1.0, v1.dot(v2) / (v1.length()*v2.length())))
+                        angle = math.acos(dot)
+                else:
+                    angle = radians(self.angle)
+                bs = BendingSpring(
+                    self.selected[0],
+                    self.selected[1],
+                    self.selected[2],
+                    angle,
+                    self.stiffness,
+                )
+                self.app.bending_springs.append(bs)
+                self.app.push_undo(lambda bs=bs: self.app._remove_bending(bs))
+                self.cancel()
+                self.sidebar.app.set_mode("drag")
+                return True
 
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             if event.pos[0] < self.sidebar.screen.get_width() - self.sidebar.visible_width():

--- a/builder_ui/tools/circle_tool.py
+++ b/builder_ui/tools/circle_tool.py
@@ -128,32 +128,31 @@ class CircleTool(Tool):
         if not super().handle_event(event):
             return False
 
-        if self.sidebar.visible:
-            if self.radius_field.handle_event(event):
+        if self.radius_field.handle_event(event):
+            return True
+        if self.segments_field.handle_event(event):
+            return True
+        if self.stiff_field.handle_event(event):
+            return True
+        if self.include_bend and self.bstiff_field.handle_event(event):
+            return True
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.bend_rect.collidepoint(event.pos):
+                self.include_bend = not self.include_bend
                 return True
-            if self.segments_field.handle_event(event):
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.create_rect.collidepoint(event.pos) and self.center:
+                self.app.create_circle(
+                    self.center,
+                    self.radius,
+                    self.segments,
+                    self.stiffness,
+                    self.include_bend,
+                    self.bend_stiffness,
+                )
+                self.cancel()
+                self.sidebar.app.set_mode("drag")
                 return True
-            if self.stiff_field.handle_event(event):
-                return True
-            if self.include_bend and self.bstiff_field.handle_event(event):
-                return True
-            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-                if self.bend_rect.collidepoint(event.pos):
-                    self.include_bend = not self.include_bend
-                    return True
-            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-                if self.create_rect.collidepoint(event.pos) and self.center:
-                    self.app.create_circle(
-                        self.center,
-                        self.radius,
-                        self.segments,
-                        self.stiffness,
-                        self.include_bend,
-                        self.bend_stiffness,
-                    )
-                    self.cancel()
-                    self.sidebar.app.set_mode("drag")
-                    return True
 
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             # click in world area to set center

--- a/builder_ui/tools/environment_tool.py
+++ b/builder_ui/tools/environment_tool.py
@@ -136,17 +136,16 @@ class EnvironmentTool(Tool):
         """Forward events to environment sliders."""
         if not super().handle_event(event):
             return False
-        if self.sidebar.visible:
-            if self.gx_field.handle_event(event):
-                return True
-            if self.gy_field.handle_event(event):
-                return True
-            if self.rep_rad_field.handle_event(event):
-                return True
-            if self.rep_str_field.handle_event(event):
-                return True
-            if self.damp_field.handle_event(event):
-                return True
-            if self.temp_field.handle_event(event):
-                return True
+        if self.gx_field.handle_event(event):
+            return True
+        if self.gy_field.handle_event(event):
+            return True
+        if self.rep_rad_field.handle_event(event):
+            return True
+        if self.rep_str_field.handle_event(event):
+            return True
+        if self.damp_field.handle_event(event):
+            return True
+        if self.temp_field.handle_event(event):
+            return True
         return False

--- a/builder_ui/tools/grid_tool.py
+++ b/builder_ui/tools/grid_tool.py
@@ -41,11 +41,10 @@ class GridTool(Tool):
         """Handle mouse input for grid toggling and spacing."""
         if not super().handle_event(event):
             return False
-        if self.sidebar.visible:
-            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-                if self.toggle_rect.collidepoint(event.pos):
-                    self.app.toggle_grid()
-                    return True
-            if self.size_field.handle_event(event):
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.toggle_rect.collidepoint(event.pos):
+                self.app.toggle_grid()
                 return True
+        if self.size_field.handle_event(event):
+            return True
         return False

--- a/builder_ui/tools/hook_arm_tool.py
+++ b/builder_ui/tools/hook_arm_tool.py
@@ -176,47 +176,45 @@ class HookArmTool(Tool):
         """Manage UI interaction and base selection."""
         if not super().handle_event(event):
             return False
-
-        if self.sidebar.visible:
-            if self.seg_field.handle_event(event):
+        if self.seg_field.handle_event(event):
+            return True
+        if self.space_field.handle_event(event):
+            return True
+        if self.mass_field.handle_event(event):
+            return True
+        if self.radius_field.handle_event(event):
+            return True
+        if self.stiff_field.handle_event(event):
+            return True
+        if self.speed_field.handle_event(event):
+            return True
+        if self.color_field.handle_event(event):
+            return True
+        if self.high_field.handle_event(event):
+            return True
+        if self.adh_field.handle_event(event):
+            return True
+        if self.key_field.handle_event(event):
+            return True
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.create_rect.collidepoint(event.pos) and self.base:
+                self.app.create_hook_arm(
+                    self.base,
+                    self.direction,
+                    self.segments,
+                    self.spacing,
+                    self.mass,
+                    self.radius,
+                    self.stiffness,
+                    self.color,
+                    self.high_drag_color,
+                    self.adhesion_factor,
+                    self.cycle_key,
+                    self.cycle_speed,
+                )
+                self.cancel()
+                self.sidebar.app.set_mode("drag")
                 return True
-            if self.space_field.handle_event(event):
-                return True
-            if self.mass_field.handle_event(event):
-                return True
-            if self.radius_field.handle_event(event):
-                return True
-            if self.stiff_field.handle_event(event):
-                return True
-            if self.speed_field.handle_event(event):
-                return True
-            if self.color_field.handle_event(event):
-                return True
-            if self.high_field.handle_event(event):
-                return True
-            if self.adh_field.handle_event(event):
-                return True
-            if self.key_field.handle_event(event):
-                return True
-            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-                if self.create_rect.collidepoint(event.pos) and self.base:
-                    self.app.create_hook_arm(
-                        self.base,
-                        self.direction,
-                        self.segments,
-                        self.spacing,
-                        self.mass,
-                        self.radius,
-                        self.stiffness,
-                        self.color,
-                        self.high_drag_color,
-                        self.adhesion_factor,
-                        self.cycle_key,
-                        self.cycle_speed,
-                    )
-                    self.cancel()
-                    self.sidebar.app.set_mode("drag")
-                    return True
 
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             if event.pos[0] < self.sidebar.screen.get_width() - self.sidebar.visible_width():

--- a/builder_ui/tools/inspect_tool.py
+++ b/builder_ui/tools/inspect_tool.py
@@ -214,30 +214,28 @@ class InspectTool(Tool):
         """Process selection and slider events."""
         if not super().handle_event(event):
             return False
-
-        if self.sidebar.visible:
-            if self.particle:
-                if self.color_field.handle_event(event):
-                    return True
-                if self.mass_field.handle_event(event):
-                    return True
-                if self.radius_field.handle_event(event):
-                    return True
-            elif self.spring:
-                if self.rest_field.handle_event(event):
-                    return True
-                if self.stiff_field.handle_event(event):
-                    return True
-                if self.max_field.handle_event(event):
-                    return True
-                if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1 and self.invis_rect.collidepoint(event.pos):
-                    self._toggle_invisible()
-                    return True
-            elif self.bend:
-                if self.bangle_field.handle_event(event):
-                    return True
-                if self.bstiff_field.handle_event(event):
-                    return True
+        if self.particle:
+            if self.color_field.handle_event(event):
+                return True
+            if self.mass_field.handle_event(event):
+                return True
+            if self.radius_field.handle_event(event):
+                return True
+        elif self.spring:
+            if self.rest_field.handle_event(event):
+                return True
+            if self.stiff_field.handle_event(event):
+                return True
+            if self.max_field.handle_event(event):
+                return True
+            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1 and self.invis_rect.collidepoint(event.pos):
+                self._toggle_invisible()
+                return True
+        elif self.bend:
+            if self.bangle_field.handle_event(event):
+                return True
+            if self.bstiff_field.handle_event(event):
+                return True
 
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             if event.pos[0] < self.sidebar.screen.get_width() - self.sidebar.visible_width():

--- a/builder_ui/tools/particle_tool.py
+++ b/builder_ui/tools/particle_tool.py
@@ -63,11 +63,10 @@ class ParticleTool(Tool):
         """Forward input events to particle option widgets."""
         if not super().handle_event(event):
             return False
-        if self.sidebar.visible:
-            if self.color_field.handle_event(event):
-                return True
-            if self.mass_field.handle_event(event):
-                return True
-            if self.radius_field.handle_event(event):
-                return True
+        if self.color_field.handle_event(event):
+            return True
+        if self.mass_field.handle_event(event):
+            return True
+        if self.radius_field.handle_event(event):
+            return True
         return False

--- a/builder_ui/tools/rod_tool.py
+++ b/builder_ui/tools/rod_tool.py
@@ -248,46 +248,44 @@ class RodTool(Tool):
         """Process mouse input for rod placement and option toggles."""
         if not super().handle_event(event):
             return False
-
-        if self.sidebar.visible:
-            if self.radius_field.handle_event(event):
+        if self.radius_field.handle_event(event):
+            return True
+        if self.length_field.handle_event(event):
+            return True
+        if self.segments_field.handle_event(event):
+            return True
+        if self.skel_count_field.handle_event(event):
+            return True
+        if self.stiff_field.handle_event(event):
+            return True
+        if self.include_bend and self.bstiff_field.handle_event(event):
+            return True
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.bend_rect.collidepoint(event.pos):
+                self.include_bend = not self.include_bend
                 return True
-            if self.length_field.handle_event(event):
+            if self.cyto_rect.collidepoint(event.pos):
+                self.include_cytoskeleton = not self.include_cytoskeleton
                 return True
-            if self.segments_field.handle_event(event):
+            if self.skeleton_rect.collidepoint(event.pos):
+                self.include_skeleton = not self.include_skeleton
                 return True
-            if self.skel_count_field.handle_event(event):
+            if self.create_rect.collidepoint(event.pos) and self.center:
+                self.app.create_rod(
+                    self.center,
+                    self.radius,
+                    self.length,
+                    self.segments,
+                    self.include_cytoskeleton,
+                    self.include_skeleton,
+                    self.skeleton_count,
+                    self.stiffness,
+                    self.include_bend,
+                    self.bend_stiffness,
+                )
+                self.cancel()
+                self.sidebar.app.set_mode("drag")
                 return True
-            if self.stiff_field.handle_event(event):
-                return True
-            if self.include_bend and self.bstiff_field.handle_event(event):
-                return True
-            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-                if self.bend_rect.collidepoint(event.pos):
-                    self.include_bend = not self.include_bend
-                    return True
-                if self.cyto_rect.collidepoint(event.pos):
-                    self.include_cytoskeleton = not self.include_cytoskeleton
-                    return True
-                if self.skeleton_rect.collidepoint(event.pos):
-                    self.include_skeleton = not self.include_skeleton
-                    return True
-                if self.create_rect.collidepoint(event.pos) and self.center:
-                    self.app.create_rod(
-                        self.center,
-                        self.radius,
-                        self.length,
-                        self.segments,
-                        self.include_cytoskeleton,
-                        self.include_skeleton,
-                        self.skeleton_count,
-                        self.stiffness,
-                        self.include_bend,
-                        self.bend_stiffness,
-                    )
-                    self.cancel()
-                    self.sidebar.app.set_mode("drag")
-                    return True
 
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             if event.pos[0] < self.sidebar.screen.get_width() - self.sidebar.visible_width():

--- a/builder_ui/tools/spring_tool.py
+++ b/builder_ui/tools/spring_tool.py
@@ -41,7 +41,6 @@ class SpringTool(Tool):
         """Forward input events to the stiffness slider."""
         if not super().handle_event(event):
             return False
-        if self.sidebar.visible:
-            if self.stiff_field.handle_event(event):
-                return True
+        if self.stiff_field.handle_event(event):
+            return True
         return False


### PR DESCRIPTION
## Summary
- centralise active/visible checks in Tool.handle_event
- rely on base handle_event in all sidebar tools to avoid duplicate checks
- document shared event guard in README and AGENTS

## Testing
- `python -m py_compile builder_ui/tools/base.py builder_ui/tools/particle_tool.py builder_ui/tools/spring_tool.py builder_ui/tools/circle_tool.py builder_ui/tools/grid_tool.py builder_ui/tools/environment_tool.py builder_ui/tools/hook_arm_tool.py builder_ui/tools/inspect_tool.py builder_ui/tools/rod_tool.py builder_ui/tools/bending_spring_tool.py`

------
https://chatgpt.com/codex/tasks/task_e_688fc7360fc88325af9e8c83901176c5