### PR TITLE
Annotate builder UI callbacks with Callable signatures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,5 @@ There are no automated tests; run the demo scripts manually to verify behaviour.
   and arms without breaking subsequent undo operations.
 - Tool base class now performs active/visibility checks in ``handle_event``,
   removing duplicate logic from individual tools.
+- Sidebar field callbacks now use explicit ``Callable`` type hints for more
+  reliable static checking.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Pylife is a small collection of Python scripts for experimenting with 2D physics
     mimic contracting or extending structures.
   * **Developer-friendly** – comprehensive docstrings document the builder UI
     and creation script.
+  * **Typed callbacks** – sidebar widgets declare explicit ``Callable``
+    signatures for getters and setters, aiding static type checkers.
 
 ### Using high-drag particles
 

--- a/builder_ui/fields.py
+++ b/builder_ui/fields.py
@@ -1,5 +1,7 @@
 """Sidebar input widgets such as sliders, colour selectors and key fields."""
 
+from typing import Callable
+
 import pygame
 from color_picker import choose_color
 
@@ -9,7 +11,17 @@ class SliderField:
 
     BOX_WIDTH = 50
 
-    def __init__(self, label, min_val, max_val, get_value, set_value, x, y, width):
+    def __init__(
+        self,
+        label: str,
+        min_val: float,
+        max_val: float,
+        get_value: Callable[[], float],
+        set_value: Callable[[float], None],
+        x: int,
+        y: int,
+        width: int,
+    ):
         """Initialise a new slider widget.
 
         Parameters
@@ -29,8 +41,8 @@ class SliderField:
         self.label = label
         self.min = min_val
         self.max = max_val
-        self.get_value = get_value
-        self.set_value = set_value
+        self.get_value: Callable[[], float] = get_value
+        self.set_value: Callable[[float], None] = set_value
         self.font = pygame.font.SysFont(None, 22)
 
         slider_width = width - self.BOX_WIDTH - 10
@@ -175,7 +187,15 @@ class ColorField:
     BOX_WIDTH = 70
     COLOR_SIZE = 24
 
-    def __init__(self, label, get_color, set_color, x, y, width):
+    def __init__(
+        self,
+        label: str,
+        get_color: Callable[[], tuple[int, int, int]],
+        set_color: Callable[[tuple[int, int, int]], None],
+        x: int,
+        y: int,
+        width: int,
+    ):
         """Initialise a colour selection field.
 
         Parameters
@@ -189,8 +209,8 @@ class ColorField:
         """
 
         self.label = label
-        self.get_color = get_color
-        self.set_color = set_color
+        self.get_color: Callable[[], tuple[int, int, int]] = get_color
+        self.set_color: Callable[[tuple[int, int, int]], None] = set_color
         self.font = pygame.font.SysFont(None, 22)
 
         self.color_rect = pygame.Rect(x, y + 14, self.COLOR_SIZE, self.COLOR_SIZE)
@@ -300,7 +320,15 @@ class KeyField:
 
     BOX_WIDTH = 60
 
-    def __init__(self, label, get_key, set_key, x, y, width):
+    def __init__(
+        self,
+        label: str,
+        get_key: Callable[[], int | None],
+        set_key: Callable[[int | None], None],
+        x: int,
+        y: int,
+        width: int,
+    ):
         """Create an editable key field.
 
         Parameters
@@ -314,8 +342,8 @@ class KeyField:
         """
 
         self.label = label
-        self.get_key = get_key
-        self.set_key = set_key
+        self.get_key: Callable[[], int | None] = get_key
+        self.set_key: Callable[[int | None], None] = set_key
         self.font = pygame.font.SysFont(None, 22)
 
         self.box_rect = pygame.Rect(x, y + 10, self.BOX_WIDTH, 22)

--- a/builder_ui/tools/hook_arm_tool.py
+++ b/builder_ui/tools/hook_arm_tool.py
@@ -60,17 +60,17 @@ class HookArmTool(Tool):
             "Speed", 50, 1000, lambda: self.cycle_speed, self._set_speed, x, y, width
         )
         y += 40
-        self.color_field = ColorField("Color", lambda: self.color, self._set_color, x, y, width)
+        self.color_field = ColorField("Color", self._get_color, self._set_color, x, y, width)
         y += 40
         self.high_field = ColorField(
-            "HDrag", lambda: self.high_drag_color, self._set_high_color, x, y, width
+            "HDrag", self._get_high_color, self._set_high_color, x, y, width
         )
         y += 40
         self.adh_field = SliderField(
             "AdhesMF", 1, 20, lambda: self.adhesion_factor, self._set_adhesion, x, y, width
         )
         y += 40
-        self.key_field = KeyField("Cycle", lambda: self.cycle_key, self._set_key, x, y, width)
+        self.key_field = KeyField("Cycle", self._get_key, self._set_key, x, y, width)
         y += 40
         self.create_rect = pygame.Rect(x, y, width, self.sidebar.BUTTON_HEIGHT)
 
@@ -99,17 +99,29 @@ class HookArmTool(Tool):
         """Set cycle speed for automatic motion."""
         self.cycle_speed = max(10, value)
 
-    def _set_color(self, color):
+    def _get_color(self) -> tuple[int, int, int]:
+        """Return the default arm colour."""
+        return self.color
+
+    def _set_color(self, color: tuple[int, int, int]) -> None:
         """Set default arm colour."""
         self.color = color
 
-    def _set_high_color(self, color):
+    def _get_high_color(self) -> tuple[int, int, int]:
+        """Return the high-drag arm colour."""
+        return self.high_drag_color
+
+    def _set_high_color(self, color: tuple[int, int, int]) -> None:
         """Set colour used when high drag is active."""
         self.high_drag_color = color
 
     def _set_adhesion(self, value: float):
         """Set mass multiplier applied during adhesion."""
         self.adhesion_factor = max(1, value)
+
+    def _get_key(self) -> int | None:
+        """Return the keyboard key used to cycle the arm."""
+        return self.cycle_key
 
     def _set_key(self, value: int | None):
         """Set keyboard key used to cycle the arm."""

--- a/builder_ui/tools/inspect_tool.py
+++ b/builder_ui/tools/inspect_tool.py
@@ -23,50 +23,50 @@ class InspectTool(Tool):
         y = sidebar.extra_start_y
 
         self.color_field = ColorField(
-            "P Color", lambda: self._get_color(), self._set_color, x, y, width
+            "P Color", self._get_color, self._set_color, x, y, width
         )
         y += 40
         self.mass_field = SliderField(
-            "P Mass", 0.1, 10.0, lambda: self._get_mass(), self._set_mass, x, y, width
+            "P Mass", 0.1, 10.0, self._get_mass, self._set_mass, x, y, width
         )
         y += 40
         self.radius_field = SliderField(
-            "P Radius", 1, 50, lambda: self._get_radius(), self._set_radius, x, y, width
+            "P Radius", 1, 50, self._get_radius, self._set_radius, x, y, width
         )
         y += 40
         self.rest_field = SliderField(
-            "S Rest", 1, 400, lambda: self._get_rest(), self._set_rest, x, y, width
+            "S Rest", 1, 400, self._get_rest, self._set_rest, x, y, width
         )
         y += 40
         self.stiff_field = SliderField(
-            "S Stiff", 10, 1000, lambda: self._get_stiff(), self._set_stiff, x, y, width
+            "S Stiff", 10, 1000, self._get_stiff, self._set_stiff, x, y, width
         )
         y += 40
         self.max_field = SliderField(
-            "S MaxF", 0, 2000, lambda: self._get_max(), self._set_max, x, y, width
+            "S MaxF", 0, 2000, self._get_max, self._set_max, x, y, width
         )
         y += 40
         self.bangle_field = SliderField(
-            "B Ang", 0, 180, lambda: self._get_bangle(), self._set_bangle, x, y, width
+            "B Ang", 0, 180, self._get_bangle, self._set_bangle, x, y, width
         )
         y += 40
         self.bstiff_field = SliderField(
-            "B Stiff", 10, 1000, lambda: self._get_bstiff(), self._set_bstiff, x, y, width
+            "B Stiff", 10, 1000, self._get_bstiff, self._set_bstiff, x, y, width
         )
         y += 40
         self.invis_rect = pygame.Rect(x, y, width, self.sidebar.BUTTON_HEIGHT)
 
     # ---------------- helpers
-    def _get_color(self):
+    def _get_color(self) -> tuple[int, int, int]:
         """Return the selected particle colour or white."""
         return self.particle.color if self.particle else (255, 255, 255)
 
-    def _set_color(self, color):
+    def _set_color(self, color: tuple[int, int, int]) -> None:
         """Update the selected particle colour."""
         if self.particle:
             self.particle.color = color
 
-    def _get_mass(self):
+    def _get_mass(self) -> float:
         """Return selected particle mass."""
         return self.particle.mass if self.particle else 0
 
@@ -75,7 +75,7 @@ class InspectTool(Tool):
         if self.particle:
             self.particle.mass = max(0.1, value)
 
-    def _get_radius(self):
+    def _get_radius(self) -> float:
         """Return selected particle radius."""
         return self.particle.radius if self.particle else 0
 
@@ -84,7 +84,7 @@ class InspectTool(Tool):
         if self.particle:
             self.particle.radius = max(1, int(value))
 
-    def _get_rest(self):
+    def _get_rest(self) -> float:
         """Return spring rest length."""
         return self.spring.rest_length if self.spring else 0
 
@@ -93,7 +93,7 @@ class InspectTool(Tool):
         if self.spring:
             self.spring.rest_length = max(1, value)
 
-    def _get_stiff(self):
+    def _get_stiff(self) -> float:
         """Return spring stiffness."""
         return self.spring.stiffness if self.spring else 0
 
@@ -102,7 +102,7 @@ class InspectTool(Tool):
         if self.spring:
             self.spring.stiffness = max(10, value)
 
-    def _get_bangle(self):
+    def _get_bangle(self) -> float:
         """Return bend rest angle in degrees."""
         return math.degrees(self.bend.rest_angle) if self.bend else 0
 
@@ -111,7 +111,7 @@ class InspectTool(Tool):
         if self.bend:
             self.bend.rest_angle = math.radians(max(0, value))
 
-    def _get_bstiff(self):
+    def _get_bstiff(self) -> float:
         """Return bend stiffness."""
         return self.bend.stiffness if self.bend else 0
 
@@ -120,7 +120,7 @@ class InspectTool(Tool):
         if self.bend:
             self.bend.stiffness = max(10, value)
 
-    def _get_max(self):
+    def _get_max(self) -> float:
         """Return spring max force or ``0`` if unlimited."""
         if not self.spring:
             return 0

--- a/builder_ui/tools/particle_tool.py
+++ b/builder_ui/tools/particle_tool.py
@@ -20,8 +20,8 @@ class ParticleTool(Tool):
 
         self.color_field = ColorField(
             "Color",
-            lambda: self.app.particle.color,
-            lambda c: setattr(self.app.particle, "color", c),
+            self._get_color,
+            self._set_color,
             x,
             y,
             width,
@@ -31,8 +31,8 @@ class ParticleTool(Tool):
             "Mass",
             0.1,
             10.0,
-            lambda: self.app.particle.mass,
-            lambda v: setattr(self.app.particle, "mass", max(0.1, v)),
+            self._get_mass,
+            self._set_mass,
             x,
             y,
             width,
@@ -42,8 +42,8 @@ class ParticleTool(Tool):
             "Radius",
             1,
             50,
-            lambda: self.app.particle.radius,
-            lambda v: setattr(self.app.particle, "radius", max(1, int(v))),
+            self._get_radius,
+            self._set_radius,
             x,
             y,
             width,
@@ -70,3 +70,28 @@ class ParticleTool(Tool):
         if self.radius_field.handle_event(event):
             return True
         return False
+
+    # ---------------- value helpers
+    def _get_color(self) -> tuple[int, int, int]:
+        """Return the default particle colour."""
+        return self.app.particle.color
+
+    def _set_color(self, color: tuple[int, int, int]) -> None:
+        """Update the default particle colour."""
+        self.app.particle.color = color
+
+    def _get_mass(self) -> float:
+        """Return the default particle mass."""
+        return self.app.particle.mass
+
+    def _set_mass(self, value: float) -> None:
+        """Set the default particle mass."""
+        self.app.particle.mass = max(0.1, value)
+
+    def _get_radius(self) -> float:
+        """Return the default particle radius."""
+        return self.app.particle.radius
+
+    def _set_radius(self, value: float) -> None:
+        """Set the default particle radius."""
+        self.app.particle.radius = max(1, int(value))


### PR DESCRIPTION
## Summary
- add explicit `Callable` annotations for slider, color, and key widgets
- replace ad-hoc lambdas with typed helper methods in particle, inspect and hook arm tools
- document typed callbacks in README and AGENTS

## Testing
- `python -m py_compile builder_ui/fields.py builder_ui/tools/hook_arm_tool.py builder_ui/tools/inspect_tool.py builder_ui/tools/particle_tool.py`


------
https://chatgpt.com/codex/tasks/task_e_688fcbec10e883259dd4c16d49126024