### PR TITLE
Add module docstrings for core and UI modules

### DIFF
--- a/builder_ui/theme.py
+++ b/builder_ui/theme.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
+"""Theme token definitions with runtime switchable dark and light palettes."""
 
-# Multiple theme support. We expose module-level tokens that can be switched
-# at runtime via set_theme().
+from __future__ import annotations
 
 THEMES: dict[str, dict[str, tuple[int, int, int] | int]] = {
     "dark": {

--- a/particle.py
+++ b/particle.py
@@ -1,4 +1,5 @@
-# particle.py
+"""Verlet-integrated point mass with per-particle drag."""
+
 import pygame
 
 class Particle:

--- a/renderer.py
+++ b/renderer.py
@@ -1,4 +1,5 @@
-# renderer.py
+"""World renderer with camera transforms and drawing helpers."""
+
 import pygame
 from pygame import gfxdraw
 from builder_ui import theme

--- a/spring.py
+++ b/spring.py
@@ -1,4 +1,5 @@
-# spring.py
+"""Linear spring obeying Hooke's law with optional break force."""
+
 import pygame
 from particle import Particle
 

--- a/start_create.py
+++ b/start_create.py
@@ -1,3 +1,5 @@
+"""Interactive builder for creating and editing particles and constraints."""
+
 import pygame
 import math
 from typing import Callable, Iterable


### PR DESCRIPTION
## Summary
- add concise module-level docstrings to particle, spring, renderer, start_create, and builder_ui/theme
- remove redundant file header comments

## Testing
- `python -m py_compile particle.py spring.py renderer.py start_create.py builder_ui/theme.py`


------
https://chatgpt.com/codex/tasks/task_e_68a227a43c788325aaf43d62177fe988