### PR TITLE
Improve collision neighbor search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ graph TD
   - `particle.py`: Verlet‑integrated point mass with per‑particle drag.
   - `spring.py`: Linear springs with Hooke’s law, optional break force, color coded by stretch/compression.
   - `bending_spring.py`: Angular constraint maintaining an angle p1–p2–p3.
-  - `physics.py`: `PhysicsEngine` orchestrating gravity, springs, bends, short‑range repulsion, viscous drag scaled by per‑particle drag, Brownian noise, wall proximity friction, and integration.
+  - `physics.py`: `PhysicsEngine` orchestrating gravity, springs, bends, short‑range repulsion, viscous drag scaled by per‑particle drag, Brownian noise, wall proximity friction, and integration. Collisions use a spatial hash with a separate configurable cell size.
   - `renderer.py`: World/screen transforms, camera zoom, drawing springs, bends (dashed), particles (with red outline for high‑drag).
 
 - Structures and helpers
@@ -141,7 +141,7 @@ Scenes are serialized to JSON via `builder_io.py`. Loading rebuilds objects and 
 - `bending`: list of `{ p1, p2, p3, angle, stiff }`
 - `arms`: list of
   - `particles` (indices), `springs` (indices into global springs), `rest_lengths`, `max_lengths`, `cycle_speed`, `color`, `high_color`, `adhesion` (mass factor), `orig_mass`, `adhesion_drag`, `orig_drag`, `cycle_key`
-- `physics`: `{ gravity: [gx, gy], repulsion_radius, repulsion_strength, temperature, damping_coeff }`
+- `physics`: `{ gravity: [gx, gy], repulsion_radius, repulsion_strength, temperature, damping_coeff, collisions, collision_elasticity, collision_bucket_size }`
 
 ### Example
 
@@ -156,7 +156,7 @@ Scenes are serialized to JSON via `builder_io.py`. Loading rebuilds objects and 
   ],
   "bending": [],
   "arms": [],
-  "physics": {"gravity": [0, 0], "repulsion_radius": 30, "repulsion_strength": 1000, "temperature": 0, "damping_coeff": 1}
+  "physics": {"gravity": [0, 0], "repulsion_radius": 30, "repulsion_strength": 1000, "temperature": 0, "damping_coeff": 1, "collisions": true, "collision_elasticity": 1.0, "collision_bucket_size": 0}
 }
 ```
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -163,7 +163,7 @@ Loading rebuilds references and re‑registers variable elements and key binding
 - `BendingSpring(p1, p2, p3, rest_angle_rad, stiffness)`
 - `VariableSpring(..., alt_rest_length, key=None, mode='hold'|'toggle', change_speed=..., ...)`
 - `VariableParticle(..., base_drag=..., alt_drag=..., key=None, mode='hold'|'toggle', change_speed=...)`
-- `PhysicsEngine(particles, springs, bending_springs=None, gravity=(0,0), repulsion_radius=..., repulsion_strength=..., temperature=..., damping_coeff=...)`
+- `PhysicsEngine(particles, springs, bending_springs=None, gravity=(0,0), repulsion_radius=..., repulsion_strength=..., temperature=..., damping_coeff=..., collision_bucket_size=...)`
   - `set_screen_size(w, h)`, `set_play_area(pygame.Rect)`, `update(dt)`
 
 ---
@@ -193,7 +193,16 @@ for i in range(segments):
     p1, p2 = particles[i], particles[(i+1)%segments]
     springs.append(Spring(p1, p2, (p2.pos - p1.pos).length(), stiffness=k))
 
-engine = PhysicsEngine(particles, springs, repulsion_radius=25, repulsion_strength=800, temperature=200, damping_coeff=1.0)
+max_r = max((p.radius for p in particles), default=0)
+engine = PhysicsEngine(
+    particles,
+    springs,
+    repulsion_radius=25,
+    repulsion_strength=800,
+    temperature=200,
+    damping_coeff=1.0,
+    collision_bucket_size=max_r * 2,
+)
 engine.set_screen_size(*screen.get_size())
 renderer = Renderer(screen)
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Number keys **1–0** switch between the first ten sidebar tools in order and ea
   * `bending_spring.py` – maintains an angle between three particles.
   * `physics.py` – contains ``PhysicsEngine`` which integrates particles each
     frame.  The engine applies gravity, spring forces, short range repulsion,
-    optional collision resolution with per-particle restitution, viscous drag scaled by each
-    particle's ``drag`` multiplier and Brownian noise.
+    optional collision resolution with per-particle restitution using a spatial hash with a separate cell size,
+    viscous drag scaled by each particle's ``drag`` multiplier and Brownian noise.
   * `renderer.py` – draws particles, springs and bending springs to the pygame window.
   * `structures.py` – helper functions to build shapes like circular walls or rods.
   * `builder_ui/` and `color_picker.py` – the sidebar widgets and the cross‑platform colour selection utility. Tools in this

--- a/builder_ui/config.py
+++ b/builder_ui/config.py
@@ -111,6 +111,8 @@ class EnvironmentParams:
         Coefficient for viscous damping.
     collisions:
         Toggle for particle-particle collision handling.
+    collision_bucket_size:
+        Spatial-hash cell size for collisions; ``0`` chooses an automatic value.
     """
 
     gravity: pygame.Vector2 = field(default_factory=lambda: pygame.Vector2(0, 0))
@@ -119,6 +121,7 @@ class EnvironmentParams:
     temperature: float = 0.0
     damping: float = 1.0
     collisions: bool = True
+    collision_bucket_size: float = 0.0
 
 
 __all__ = [

--- a/physics.py
+++ b/physics.py
@@ -43,6 +43,9 @@ class PhysicsEngine:
         Base coefficient ``e`` (0–1) controlling bounce when resolving
         collisions. The value is multiplied by the ``elasticity`` of each
         particle involved.
+    collision_bucket_size:
+        Size of the spatial-hash cells used for collision detection. ``None``
+        chooses twice the maximum particle radius each step.
     """
     def __init__(
         self,
@@ -54,8 +57,9 @@ class PhysicsEngine:
         repulsion_strength=100,
         temperature=1.0,
         damping_coeff=1.0,
-        collisions_enabled: bool = True,
+    collisions_enabled: bool = True,
         collision_elasticity: float = 1.0,
+        collision_bucket_size: float | None = None,
     ):
         self.particles = particles
         self.springs = springs
@@ -67,6 +71,11 @@ class PhysicsEngine:
         self.damping_coeff = damping_coeff
         self.collisions_enabled = bool(collisions_enabled)
         self.collision_elasticity = float(collision_elasticity)
+        self.collision_bucket_size = (
+            float(collision_bucket_size)
+            if collision_bucket_size and collision_bucket_size > 0
+            else None
+        )
         # Updated dynamically by the app when the window resizes
         self._screen_size: tuple[int, int] | None = None
         # Optional world-space playable area used for boundary proximity
@@ -84,6 +93,9 @@ class PhysicsEngine:
         self._repulsion_buckets: dict[tuple[int, int], list[int]] = {}
         self._repulsion_bucket_size: float = max(1e-6, float(self.repulsion_radius))
         self._last_repulsion_radius: float = float(self.repulsion_radius)
+        # Spatial hash reused by collisions when repulsion builds it
+        self._collision_buckets: dict[tuple[int, int], list[int]] = {}
+        self._collision_bucket_size: float = 0.0
 
     def set_fixed_timestep(
         self,
@@ -241,9 +253,21 @@ class PhysicsEngine:
         self._repulsion_rebuild_interval_steps = max(1, int(rebuild_interval_steps))
         self._repulsion_steps_since_rebuild = 0
         self._repulsion_buckets.clear()
+        self._collision_buckets.clear()
+
+    def _get_collision_bucket_size(self) -> float:
+        """Return the spatial-hash cell size for collisions."""
+        if self.collision_bucket_size and self.collision_bucket_size > 0:
+            return max(1e-6, float(self.collision_bucket_size))
+        max_r = 0.0
+        for p in self.particles:
+            r = getattr(p, "radius", 0) or 0
+            if r > max_r:
+                max_r = r
+        return max(1e-6, 2 * max_r)
 
     def _build_repulsion_buckets(self) -> None:
-        bs = max(1e-6, float(self.repulsion_radius))
+        bs = max(self._get_collision_bucket_size(), float(self.repulsion_radius))
         self._repulsion_bucket_size = bs
         self._last_repulsion_radius = float(self.repulsion_radius)
         buckets: dict[tuple[int, int], list[int]] = {}
@@ -252,12 +276,26 @@ class PhysicsEngine:
             cy = int(math.floor(p.pos.y / bs))
             buckets.setdefault((cx, cy), []).append(i)
         self._repulsion_buckets = buckets
+        self._collision_buckets = buckets
+        self._collision_bucket_size = bs
+
+    def _build_collision_buckets(self) -> None:
+        bs = self._get_collision_bucket_size()
+        buckets: dict[tuple[int, int], list[int]] = {}
+        for i, p in enumerate(self.particles):
+            cx = int(math.floor(p.pos.x / bs))
+            cy = int(math.floor(p.pos.y / bs))
+            buckets.setdefault((cx, cy), []).append(i)
+        self._collision_buckets = buckets
+        self._collision_bucket_size = bs
 
     def _apply_repulsion(self) -> None:
         # Fast exits
         if self.repulsion_radius <= 0 or self.repulsion_strength == 0 or len(self.particles) < 2:
+            self._collision_buckets.clear()
             return
         if not self._use_spatial_hash:
+            self._collision_buckets.clear()
             # fallback O(n^2)
             for i, p1 in enumerate(self.particles):
                 for j in range(i + 1, len(self.particles)):
@@ -323,17 +361,18 @@ class PhysicsEngine:
         if not self.collisions_enabled or len(self.particles) < 2:
             return
 
-        # choose iteration strategy
-        if self._use_spatial_hash and self.repulsion_radius > 0:
-            self._build_repulsion_buckets()
-            bs = self._repulsion_bucket_size
-            buckets = self._repulsion_buckets
+        base_e = max(0.0, float(self.collision_elasticity))
+
+        if self._use_spatial_hash:
+            if not self._collision_buckets:
+                self._build_collision_buckets()
+            bs = self._collision_bucket_size
+            buckets = self._collision_buckets
             neighbor_offsets = (
                 (-1, -1), (-1, 0), (-1, 1),
                 (0, -1),  (0, 0),  (0, 1),
                 (1, -1),  (1, 0),  (1, 1),
             )
-            pairs: list[tuple[int, int]] = []
             for i, p1 in enumerate(self.particles):
                 cx = int(math.floor(p1.pos.x / bs))
                 cy = int(math.floor(p1.pos.y / bs))
@@ -342,73 +381,98 @@ class PhysicsEngine:
                     if not lst:
                         continue
                     for j in lst:
-                        if j > i:
-                            pairs.append((i, j))
+                        if j <= i:
+                            continue
+                        p2 = self.particles[j]
+                        r1 = getattr(p1, "radius", 0) or 0
+                        r2 = getattr(p2, "radius", 0) or 0
+                        if r1 <= 0 and r2 <= 0:
+                            continue
+                        delta = p2.pos - p1.pos
+                        min_dist = r1 + r2
+                        if min_dist <= 0:
+                            continue
+                        dist_sq = delta.length_squared()
+                        if dist_sq >= min_dist * min_dist:
+                            continue
+                        dist = math.sqrt(dist_sq) if dist_sq > 0 else 0.0
+                        if dist == 0:
+                            delta = pygame.Vector2(1, 0)
+                            dist = 1.0
+                        n = delta / dist
+                        overlap = min_dist - dist
+                        self._separate_and_bounce(p1, p2, n, overlap, base_e)
         else:
-            pairs = [
-                (i, j)
-                for i in range(len(self.particles))
-                for j in range(i + 1, len(self.particles))
-            ]
+            for i in range(len(self.particles)):
+                p1 = self.particles[i]
+                for j in range(i + 1, len(self.particles)):
+                    p2 = self.particles[j]
+                    r1 = getattr(p1, "radius", 0) or 0
+                    r2 = getattr(p2, "radius", 0) or 0
+                    if r1 <= 0 and r2 <= 0:
+                        continue
+                    delta = p2.pos - p1.pos
+                    min_dist = r1 + r2
+                    if min_dist <= 0:
+                        continue
+                    dist_sq = delta.length_squared()
+                    if dist_sq >= min_dist * min_dist:
+                        continue
+                    dist = math.sqrt(dist_sq) if dist_sq > 0 else 0.0
+                    if dist == 0:
+                        delta = pygame.Vector2(1, 0)
+                        dist = 1.0
+                    n = delta / dist
+                    overlap = min_dist - dist
+                    self._separate_and_bounce(p1, p2, n, overlap, base_e)
 
-        base_e = max(0.0, float(self.collision_elasticity))
+    def _separate_and_bounce(
+        self,
+        p1: Particle,
+        p2: Particle,
+        n: pygame.Vector2,
+        overlap: float,
+        base_e: float,
+    ) -> None:
+        """Resolve overlap between ``p1`` and ``p2`` and apply bounce."""
+        if p1.fixed and p2.fixed:
+            return
+        elif p1.fixed:
+            move2 = n * overlap
+            p2.pos += move2
+            p2.prev_pos += move2
+        elif p2.fixed:
+            move1 = -n * overlap
+            p1.pos += move1
+            p1.prev_pos += move1
+        else:
+            total_mass = p1.mass + p2.mass
+            move1 = -n * overlap * (p2.mass / total_mass)
+            move2 = n * overlap * (p1.mass / total_mass)
+            p1.pos += move1
+            p2.pos += move2
+            p1.prev_pos += move1
+            p2.prev_pos += move2
 
-        for i, j in pairs:
-            p1 = self.particles[i]
-            p2 = self.particles[j]
-            r1 = getattr(p1, "radius", 0) or 0
-            r2 = getattr(p2, "radius", 0) or 0
-            if r1 <= 0 and r2 <= 0:
-                continue
-            delta = p2.pos - p1.pos
-            dist = delta.length()
-            min_dist = r1 + r2
-            if dist >= min_dist or min_dist <= 0:
-                continue
-            if dist == 0:
-                delta = pygame.Vector2(1, 0)
-                dist = 1
-            n = delta / dist
-            overlap = min_dist - dist
+        e_pair = base_e * min(getattr(p1, "elasticity", 1.0), getattr(p2, "elasticity", 1.0))
+        if e_pair <= 0:
+            return
 
-            if p1.fixed and p2.fixed:
-                continue
-            elif p1.fixed:
-                move2 = n * overlap
-                p2.pos += move2
-                p2.prev_pos += move2
-            elif p2.fixed:
-                move1 = -n * overlap
-                p1.pos += move1
-                p1.prev_pos += move1
-            else:
-                total_mass = p1.mass + p2.mass
-                move1 = -n * overlap * (p2.mass / total_mass)
-                move2 = n * overlap * (p1.mass / total_mass)
-                p1.pos += move1
-                p2.pos += move2
-                p1.prev_pos += move1
-                p2.prev_pos += move2
-
-            e_pair = base_e * min(getattr(p1, "elasticity", 1.0), getattr(p2, "elasticity", 1.0))
-            if e_pair <= 0:
-                continue
-
-            v1 = p1.pos - p1.prev_pos
-            v2 = p2.pos - p2.prev_pos
-            rel = v1 - v2
-            rel_norm = rel.dot(n)
-            if rel_norm <= 0:
-                continue
-            inv1 = 0.0 if p1.fixed else 1.0 / p1.mass
-            inv2 = 0.0 if p2.fixed else 1.0 / p2.mass
-            denom = inv1 + inv2
-            if denom == 0:
-                continue
-            j_imp = (1 + e_pair) * rel_norm / denom
-            if not p1.fixed:
-                v1 -= j_imp * inv1 * n
-                p1.prev_pos = p1.pos - v1
-            if not p2.fixed:
-                v2 += j_imp * inv2 * n
-                p2.prev_pos = p2.pos - v2
+        v1 = p1.pos - p1.prev_pos
+        v2 = p2.pos - p2.prev_pos
+        rel = v1 - v2
+        rel_norm = rel.dot(n)
+        if rel_norm <= 0:
+            return
+        inv1 = 0.0 if p1.fixed else 1.0 / p1.mass
+        inv2 = 0.0 if p2.fixed else 1.0 / p2.mass
+        denom = inv1 + inv2
+        if denom == 0:
+            return
+        j_imp = (1 + e_pair) * rel_norm / denom
+        if not p1.fixed:
+            v1 -= j_imp * inv1 * n
+            p1.prev_pos = p1.pos - v1
+        if not p2.fixed:
+            v2 += j_imp * inv2 * n
+            p2.prev_pos = p2.pos - v2

--- a/start.py
+++ b/start.py
@@ -46,13 +46,21 @@ class CellWallApp:
         self.springs.extend(wall0_springs + wall1_springs + wall2_springs)
         # self._loose_particles(count=40)
 
-        self.physics = PhysicsEngine(self.particles, self.springs, gravity=(0, 0),
-                                     # repulsion_radius=100, repulsion_strength=100,
-                                     # repulsion_radius=100, repulsion_strength=1000,
-                                     # repulsion_radius=150, repulsion_strength=100,
-                                     repulsion_radius=30, repulsion_strength=1000,
-                                     # repulsion_radius=30, repulsion_strength=10000,
-                                     temperature=500, damping_coeff=1)
+        max_r = max((p.radius for p in self.particles), default=0)
+        self.physics = PhysicsEngine(
+            self.particles,
+            self.springs,
+            gravity=(0, 0),
+            # repulsion_radius=100, repulsion_strength=100,
+            # repulsion_radius=100, repulsion_strength=1000,
+            # repulsion_radius=150, repulsion_strength=100,
+            repulsion_radius=30,
+            repulsion_strength=1000,
+            # repulsion_radius=30, repulsion_strength=10000,
+            temperature=500,
+            damping_coeff=1,
+            collision_bucket_size=max_r * 2,
+        )
                                      # temperature=0, damping_coeff=1)
                                      # temperature=0, damping_coeff=0)
         # Fixed timestep for stability with fast/slow frames

--- a/start_basic.py
+++ b/start_basic.py
@@ -27,8 +27,15 @@ class CellWallApp:
         self.selected = None
 
         self._create_wall()
-        self.physics = PhysicsEngine(self.particles, self.springs, gravity=(0, 0),
-                                     repulsion_radius=100, repulsion_strength=500)
+        max_r = max((p.radius for p in self.particles), default=0)
+        self.physics = PhysicsEngine(
+            self.particles,
+            self.springs,
+            gravity=(0, 0),
+            repulsion_radius=100,
+            repulsion_strength=500,
+            collision_bucket_size=max_r * 2,
+        )
         # Fixed timestep for consistent behavior
         self.physics.set_fixed_timestep(1.0 / FPS, substeps=2)
         self.renderer = Renderer(self.screen)

--- a/start_bending_wall.py
+++ b/start_bending_wall.py
@@ -57,6 +57,7 @@ class CellWallApp:
         self.springs.extend(wall1_springs)
         self.bending_springs.extend(wall1_bending_springs)
 
+        max_r = max((p.radius for p in self.particles), default=0)
         self.physics = PhysicsEngine(
             self.particles,
             self.springs,
@@ -66,7 +67,8 @@ class CellWallApp:
             repulsion_radius=30,
             repulsion_strength=10000,
             temperature=0,
-            damping_coeff=1
+            damping_coeff=1,
+            collision_bucket_size=max_r * 2,
         )
         # Fixed timestep for stability across variable framerates
         self.physics.set_fixed_timestep(1.0 / FPS, substeps=2)

--- a/start_create.py
+++ b/start_create.py
@@ -83,6 +83,7 @@ class BuilderApp:
             temperature=self.environment.temperature,
             damping_coeff=self.environment.damping,
             collisions_enabled=self.environment.collisions,
+            collision_bucket_size=self.environment.collision_bucket_size,
         )
         # Use a fixed timestep with substeps for stability across variable framerates
         self.physics.set_fixed_timestep(1.0 / FPS, substeps=2)
@@ -851,6 +852,7 @@ class BuilderApp:
                 "damping_coeff": self.physics.damping_coeff,
                 "collisions": self.physics.collisions_enabled,
                 "collision_elasticity": self.physics.collision_elasticity,
+                "collision_bucket_size": self.physics.collision_bucket_size or 0,
             },
         }
 
@@ -976,6 +978,8 @@ class BuilderApp:
         self.physics.collisions_enabled = phys.get("collisions", True)
         self.environment.collisions = self.physics.collisions_enabled
         self.physics.collision_elasticity = phys.get("collision_elasticity", 1.0)
+        self.physics.collision_bucket_size = phys.get("collision_bucket_size", 0) or None
+        self.environment.collision_bucket_size = self.physics.collision_bucket_size or 0
 
         # refresh physics engine references so loaded objects are simulated
         self.physics.particles = self.particles

--- a/start_four_rods.py
+++ b/start_four_rods.py
@@ -86,10 +86,16 @@ class CellWallApp:
         self.springs.extend(north_springs + east_springs + south_springs + west_springs)
 
         # Physics engine setup
+        max_r = max((p.radius for p in self.particles), default=0)
         self.physics = PhysicsEngine(
-            self.particles, self.springs, gravity=(0, 0),
-            repulsion_radius=30, repulsion_strength=10000,
-            temperature=500, damping_coeff=1
+            self.particles,
+            self.springs,
+            gravity=(0, 0),
+            repulsion_radius=30,
+            repulsion_strength=10000,
+            temperature=500,
+            damping_coeff=1,
+            collision_bucket_size=max_r * 2,
         )
         # Fixed timestep for stable behavior
         self.physics.set_fixed_timestep(1.0 / FPS, substeps=2)

--- a/start_gradient_wall.py
+++ b/start_gradient_wall.py
@@ -95,10 +95,16 @@ class CellWallApp:
             self.particles.extend(particles)
             self.springs.extend(springs)
 
+        max_r = max((p.radius for p in self.particles), default=0)
         self.physics = PhysicsEngine(
-            self.particles, self.springs, gravity=(0, 0),
-            repulsion_radius=30, repulsion_strength=10000,
-            temperature=500, damping_coeff=1
+            self.particles,
+            self.springs,
+            gravity=(0, 0),
+            repulsion_radius=30,
+            repulsion_strength=10000,
+            temperature=500,
+            damping_coeff=1,
+            collision_bucket_size=max_r * 2,
         )
         # Fixed timestep for consistency
         self.physics.set_fixed_timestep(1.0 / FPS, substeps=2)

--- a/start_hook_arm.py
+++ b/start_hook_arm.py
@@ -50,6 +50,7 @@ class HookArmApp:
             self.particles.extend(arm.particles)
             self.springs.extend(arm.springs)
 
+        max_r = max((p.radius for p in self.particles), default=0)
         self.physics = PhysicsEngine(
             self.particles,
             self.springs,
@@ -58,6 +59,7 @@ class HookArmApp:
             repulsion_strength=1000,
             temperature=0,
             damping_coeff=1,
+            collision_bucket_size=max_r * 2,
         )
         # Fixed timestep keeps arms stable at variable frame times
         self.physics.set_fixed_timestep(1.0 / FPS, substeps=2)

--- a/start_rod.py
+++ b/start_rod.py
@@ -56,14 +56,22 @@ class CellWallApp:
         self.springs.extend(wall2_springs + wall1_springs)
         # self._loose_particles(count=40)
 
-        self.physics = PhysicsEngine(self.particles, self.springs, gravity=(0, 0),
-                                     # repulsion_radius=100, repulsion_strength=100,
-                                     # repulsion_radius=100, repulsion_strength=1000,
-                                     # repulsion_radius=150, repulsion_strength=100,
-                                     # repulsion_radius=30, repulsion_strength=1000,
-                                     repulsion_radius=30, repulsion_strength=10000,
-                                     # repulsion_radius=0, repulsion_strength=10000,
-                                     temperature=500, damping_coeff=1)
+        max_r = max((p.radius for p in self.particles), default=0)
+        self.physics = PhysicsEngine(
+            self.particles,
+            self.springs,
+            gravity=(0, 0),
+            # repulsion_radius=100, repulsion_strength=100,
+            # repulsion_radius=100, repulsion_strength=1000,
+            # repulsion_radius=150, repulsion_strength=100,
+            # repulsion_radius=30, repulsion_strength=1000,
+            repulsion_radius=30,
+            repulsion_strength=10000,
+            # repulsion_radius=0, repulsion_strength=10000,
+            temperature=500,
+            damping_coeff=1,
+            collision_bucket_size=max_r * 2,
+        )
                                      # temperature=0, damping_coeff=1)
                                      # temperature=0, damping_coeff=0)
         # Fixed timestep for stability


### PR DESCRIPTION
## Summary
- decouple collision neighbor search from repulsion buckets with a new `collision_bucket_size`
- reuse spatial-hash buckets and avoid temporary pairs while resolving collisions
- expose collision bucket size in environment settings and scene persistence

## Testing
- `python -m py_compile builder_ui/config.py physics.py start.py start_basic.py start_bending_wall.py start_create.py start_four_rods.py start_gradient_wall.py start_hook_arm.py start_rod.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2417cc2688325b9030eb98cb5ca92