### PR TITLE
Optimize repulsion distance checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,7 @@ Scenes are serialized to JSON via `builder_io.py`. Loading rebuilds objects and 
 - Tune stiffness and damping to avoid instability; consider `max_force` to prevent runaway springs.
 - Repulsion is O(n^2); keep radius/particle count in check or disable where not needed.
 - For sticky effects prefer raising `drag` over `fixed=True` during motion.
+- Repulsion skips square roots for distant pairs and reuses the inverse radius for speed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Number keys **1–0** switch between the first ten sidebar tools in order and ea
   * `spring.py` – linear springs that apply Hooke's law and change colour depending on stretch/compression.
   * `bending_spring.py` – maintains an angle between three particles.
   * `physics.py` – contains ``PhysicsEngine`` which integrates particles each
-    frame.  The engine applies gravity, spring forces, short range repulsion,
-    optional collision resolution with per-particle restitution using a spatial hash with a separate cell size,
-    viscous drag scaled by each particle's ``drag`` multiplier and Brownian noise.
+    frame.  The engine applies gravity, spring forces and short range
+    repulsion with squared-distance checks to skip distant pairs, optional
+    collision resolution with per-particle restitution using a spatial hash
+    with a separate cell size, viscous drag scaled by each particle's
+    ``drag`` multiplier and Brownian noise.
   * `renderer.py` – draws particles, springs and bending springs to the pygame window.
   * `structures.py` – helper functions to build shapes like circular walls or rods.
   * `builder_ui/` and `color_picker.py` – the sidebar widgets and the cross‑platform colour selection utility. Tools in this

--- a/physics.py
+++ b/physics.py
@@ -294,21 +294,27 @@ class PhysicsEngine:
         self._collision_bucket_size = bs
 
     def _apply_repulsion(self) -> None:
-        # Fast exits
+        """Push particles apart when they come within the repulsion radius."""
+
         if self.repulsion_radius <= 0 or self.repulsion_strength == 0 or len(self.particles) < 2:
             self._collision_buckets.clear()
             return
+
+        radius = self.repulsion_radius
+        inv_radius = 1.0 / radius
+        radius_sq = radius * radius
+
         if not self._use_spatial_hash:
             self._collision_buckets.clear()
-            # fallback O(n^2)
             for i, p1 in enumerate(self.particles):
                 for j in range(i + 1, len(self.particles)):
                     p2 = self.particles[j]
                     delta = p2.pos - p1.pos
-                    dist = delta.length()
-                    if dist > 0 and dist < self.repulsion_radius:
+                    dist_sq = delta.length_squared()
+                    if 0 < dist_sq < radius_sq:
+                        dist = math.sqrt(dist_sq)
                         direction = delta / dist
-                        force_magnitude = self.repulsion_strength * (self.repulsion_radius - dist) / self.repulsion_radius
+                        force_magnitude = self.repulsion_strength * (radius - dist) * inv_radius
                         force = direction * force_magnitude
                         p1.apply_force(-force)
                         p2.apply_force(force)
@@ -333,7 +339,6 @@ class PhysicsEngine:
             (1, -1),  (1, 0),  (1, 1),
         )
 
-        # For each particle, check neighbors in 3x3 surrounding cells; only pairs with j > i
         for i, p1 in enumerate(self.particles):
             cx = int(math.floor(p1.pos.x / bs))
             cy = int(math.floor(p1.pos.y / bs))
@@ -347,10 +352,11 @@ class PhysicsEngine:
                         continue
                     p2 = self.particles[j]
                     delta = p2.pos - p1.pos
-                    dist = delta.length()
-                    if dist > 0 and dist < self.repulsion_radius:
+                    dist_sq = delta.length_squared()
+                    if 0 < dist_sq < radius_sq:
+                        dist = math.sqrt(dist_sq)
                         direction = delta / dist
-                        force_magnitude = self.repulsion_strength * (self.repulsion_radius - dist) / self.repulsion_radius
+                        force_magnitude = self.repulsion_strength * (radius - dist) * inv_radius
                         force = direction * force_magnitude
                         p1.apply_force(-force)
                         p2.apply_force(force)


### PR DESCRIPTION
## Summary
- Avoid square roots for distant particle pairs by comparing squared distances
- Reuse precomputed inverse repulsion radius in repulsion force calculations
- Document repulsion performance tweaks in README and AGENTS guides

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a36e1dfc9883258d9dc3e52c3bf2c7