### PR TITLE
Cache pygame font to stop file handle leak

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,8 @@ Scenes are serialized to JSON via `builder_io.py`. Loading rebuilds objects and 
 - Control flow with early returns; avoid deep nesting.
 - No inline commentary inside code; place comments above complex logic blocks.
 - Match existing formatting; wrap long lines; don’t reformat unrelated code.
+- Reuse the default pygame font via ``builder_ui.fonts.get_font`` rather than
+  calling ``pygame.font.SysFont`` repeatedly to avoid leaking file handles.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Number keys **1–0** switch between the first ten sidebar tools in order and ea
     and creation script.
   * **Typed callbacks** – sidebar widgets declare explicit ``Callable``
     signatures for getters and setters, aiding static type checkers.
+  * **Cached fonts** – sidebar and field widgets reuse the default pygame font
+    to prevent leaking file descriptors on some systems.
 
 ### Using high-drag particles
 

--- a/builder_ui/fields.py
+++ b/builder_ui/fields.py
@@ -5,6 +5,7 @@ from typing import Callable
 import pygame
 from color_picker import choose_color
 from . import theme
+from .fonts import get_font
 
 
 class SliderField:
@@ -44,7 +45,7 @@ class SliderField:
         self.max = max_val
         self.get_value: Callable[[], float] = get_value
         self.set_value: Callable[[float], None] = set_value
-        self.font = pygame.font.SysFont(None, 22)
+        self.font = get_font(22)
 
         slider_width = width - self.BOX_WIDTH - 10
         self.slider_rect = pygame.Rect(x, y + 18, slider_width, 6)
@@ -226,7 +227,7 @@ class ColorField:
         self.label = label
         self.get_color: Callable[[], tuple[int, int, int]] = get_color
         self.set_color: Callable[[tuple[int, int, int]], None] = set_color
-        self.font = pygame.font.SysFont(None, 22)
+        self.font = get_font(22)
 
         self.color_rect = pygame.Rect(x, y + 14, self.COLOR_SIZE, self.COLOR_SIZE)
         self.box_rect = pygame.Rect(
@@ -369,7 +370,7 @@ class KeyField:
         self.label = label
         self.get_key: Callable[[], int | None] = get_key
         self.set_key: Callable[[int | None], None] = set_key
-        self.font = pygame.font.SysFont(None, 22)
+        self.font = get_font(22)
 
         self.box_rect = pygame.Rect(x, y + 10, self.BOX_WIDTH, 22)
         self.editing = False
@@ -468,7 +469,7 @@ class ButtonField:
         self.action = action
         self.active = active
         self.rect = pygame.Rect(x, y, width, self.HEIGHT)
-        self.font = pygame.font.SysFont(None, 24)
+        self.font = get_font(24)
         self.pressed = 0
 
     def draw(self, screen, offset: int = 0) -> None:

--- a/builder_ui/fonts.py
+++ b/builder_ui/fonts.py
@@ -1,0 +1,15 @@
+"""Font helpers with caching to avoid file descriptor leaks."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+import pygame
+
+
+@lru_cache(maxsize=None)
+def get_font(size: int) -> pygame.font.Font:
+    """Return a cached default pygame font of the given size."""
+    default = Path(pygame.__file__).with_name(pygame.font.get_default_font())
+    return pygame.font.Font(str(default), size)

--- a/builder_ui/fonts.py
+++ b/builder_ui/fonts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from pathlib import Path
 
 import pygame
 
@@ -11,5 +10,4 @@ import pygame
 @lru_cache(maxsize=None)
 def get_font(size: int) -> pygame.font.Font:
     """Return a cached default pygame font of the given size."""
-    default = Path(pygame.__file__).with_name(pygame.font.get_default_font())
-    return pygame.font.Font(str(default), size)
+    return pygame.font.Font(None, size)

--- a/builder_ui/sidebar.py
+++ b/builder_ui/sidebar.py
@@ -2,6 +2,7 @@
 
 import pygame
 
+from .fonts import get_font
 from .tools.particle_tool import ParticleTool
 from .tools.spring_tool import SpringTool
 from .tools.variable_spring_tool import VariableSpringTool
@@ -37,7 +38,7 @@ class SidebarUI:
 
         self.screen = screen
         self.app = app
-        self.font = pygame.font.SysFont(None, 24)
+        self.font = get_font(24)
         self.buttons = []
         self.fields = []
         self.visible = True


### PR DESCRIPTION
## Summary
- add cached font loader to avoid reopening pygame's bundled font
- reuse cached font in sidebar and UI fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4787fa490832581a096badd453366