### PR TITLE
Fix save dialog mapping for particle types

### DIFF
--- a/builder_app.py
+++ b/builder_app.py
@@ -984,7 +984,7 @@ class BuilderApp:
                             "tags": sorted(p.tags),
                         }
                         if isinstance(p, SensorParticle)
-                        else {},
+                        else {}
                     ),
                   }
                   for p in self.particles

--- a/tests/test_build_state.py
+++ b/tests/test_build_state.py
@@ -1,0 +1,24 @@
+import os
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+import pygame
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from builder_app import BuilderApp
+from variable_particle import VariableParticle
+from sensor_particle import SensorParticle
+
+
+def test_build_state_handles_variable_and_sensor() -> None:
+    app = BuilderApp()
+    vp = VariableParticle((0, 0))
+    sp = SensorParticle((1, 1))
+    app.particles = [vp, sp]
+    app.variable_particles = [vp]
+    app.sensors = [sp]
+    state = app._build_state()
+    types = [p.get("type") for p in state["particles"]]
+    assert "variable" in types
+    assert "sensor" in types
+    pygame.quit()


### PR DESCRIPTION
## Summary
- fix _build_state tuple expansion that broke saving
- add regression test covering variable and sensor particles

## Testing
- `pytest -q`
- `SDL_VIDEODRIVER=dummy python start_basic.py` (fails: TypeError `'>' not supported between instances of 'NoneType' and 'NoneType'`)
- `SDL_VIDEODRIVER=dummy python start_create.py`


------
https://chatgpt.com/codex/tasks/task_e_68a63a3e795c8325998b54a3d555b772