### PR TITLE
Enable right-click drag camera panning in builder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ graph TD
 
 - World/screen transforms live in `renderer.py` with `set_camera`, `world_to_screen`, `screen_to_world`.
 - The builder zooms with mouse wheel when the cursor is over the world area, anchoring the zoom at the mouse position.
+- Right-click dragging pans the camera.
 - Play area is rendered as a rectangle; simulation boundary clamping uses either the play area or the screen size.
 - Renderer can optionally draw fading particle trails when enabled via the environment tool.
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Mouse and keyboard controls allow you to switch modes and modify properties:
   current scene as a JSON file. Loaded scenes automatically resume simulation.
 * Hit **Undo** in the sidebar to revert the most recent addition or deletion.
 * Scroll the sidebar with the mouse wheel; scrolling stops at the list bounds.
+* Right-click and drag – pan the camera view.
 
 Particles can be grabbed with the left mouse button.  When in spring mode, click two particles to connect them. Selecting the **Arm** tool lets you click a particle, drag out a direction and then hit *Create* to spawn a hook arm. The sidebar fields let you set the arm's mass, radius, stiffness, cycle speed, colours and adhesion factor before creation, and any number of arms may share the same cycle key. The **Inspect** tool can select a particle, spring or bending spring so their properties (colour, mass, radius, elasticity, drag, rest length, stiffness, **max force** and visibility) may be edited in place. Springs and particles may also be converted between normal and variable types through this menu. A value of ``0`` for max force disables the limit. Use the Particle, Spring or Env buttons to reveal their respective sliders.
 

--- a/builder_app.py
+++ b/builder_app.py
@@ -107,6 +107,7 @@ class BuilderApp:
         self.camera_offset = pygame.Vector2(0, 0)
         self.camera_zoom = 1.0
         self.renderer.set_camera(self.camera_offset, self.camera_zoom)
+        self.panning = False
         # inform physics of current window size for boundary effects
         self.physics.set_screen_size(*self.screen.get_size())
         self.physics.set_play_area(self.play_area)
@@ -1666,6 +1667,19 @@ class BuilderApp:
                     if e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
                         self.pasting = False
                         continue
+
+                # pan camera with right mouse drag when cursor is over world area
+                if e.type == pygame.MOUSEBUTTONDOWN and e.button == 3:
+                    if e.pos[0] < self.screen.get_width() - self.ui.visible_width():
+                        self.panning = True
+                    continue
+                if e.type == pygame.MOUSEMOTION and self.panning:
+                    self.camera_offset -= pygame.Vector2(e.rel) / self.camera_zoom
+                    self.renderer.set_camera(self.camera_offset, self.camera_zoom)
+                    continue
+                if e.type == pygame.MOUSEBUTTONUP and e.button == 3 and self.panning:
+                    self.panning = False
+                    continue
 
                 if e.type == pygame.QUIT:
                     running = False


### PR DESCRIPTION
## Summary
- allow right mouse drag to pan the camera in BuilderApp
- document right-click panning in README and AGENTS guides

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6fe9fcd448325ae267ea94d73503c