### PR TITLE
Add channel protocol for variable elements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,8 @@ Scenes are serialized to JSON via `builder_io.py`. Loading rebuilds objects and 
 ### New variable elements or key‑driven behavior
 
 - Follow `variable_spring.py` and `variable_particle.py` patterns. Ensure registration maps (`vspring_keys`, `vparticle_keys`, `vbend_keys`, `cycle_keys`) are updated in create/convert/save/load paths.
+- Channel-aware objects must implement the ``ChannelControlled`` protocol
+  which defines ``set_channel_active(state: bool)``.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Number keys **1–0** switch between the first ten sidebar tools in order and ea
     and creation script.
   * **Typed callbacks** – sidebar widgets declare explicit ``Callable``
     signatures for getters and setters, aiding static type checkers.
+  * **Channel protocol** – variable elements conform to a shared
+    ``ChannelControlled`` protocol exposing ``set_channel_active`` for
+    type-safe channel signalling.
   * **Cached fonts** – sidebar and field widgets reuse the default pygame font
     to prevent leaking file descriptors on some systems.
 

--- a/builder_app.py
+++ b/builder_app.py
@@ -10,6 +10,7 @@ from spring import Spring
 from variable_spring import VariableSpring
 from variable_particle import VariableParticle
 from variable_bending_spring import VariableBendingSpring
+from channel import ChannelControlled
 from physics import PhysicsEngine
 from bending_spring import BendingSpring
 from renderer import Renderer
@@ -54,7 +55,7 @@ class BuilderApp:
         self.vspring_keys: dict[int, list[VariableSpring]] = {}
         self.vparticle_keys: dict[int, list[VariableParticle]] = {}
         self.vbend_keys: dict[int, list[VariableBendingSpring]] = {}
-        self.channels: dict[int, set[object]] = {}
+        self.channels: dict[int, set[ChannelControlled]] = {}
         self.active_channels: set[int] = set()
         self.selected = None
         self.selection_start: pygame.Vector2 | None = None
@@ -1542,15 +1543,15 @@ class BuilderApp:
             self.vbend_keys.setdefault(key, []).append(bend)
 
     # channel registration -------------------------------------------------
-    def _register_channel(self, obj: object) -> None:
+    def _register_channel(self, obj: ChannelControlled) -> None:
         """Add *obj* to the channel map if it has a channel."""
-        ch = getattr(obj, "channel", None)
+        ch = obj.channel
         if ch is not None:
             self.channels.setdefault(ch, set()).add(obj)
 
-    def update_channel(self, obj: object, channel: int | None) -> None:
+    def update_channel(self, obj: ChannelControlled, channel: int | None) -> None:
         """Move *obj* to *channel* in the channel map."""
-        old = getattr(obj, "channel", None)
+        old = obj.channel
         if old is not None:
             objs = self.channels.get(old)
             if objs:
@@ -1574,10 +1575,7 @@ class BuilderApp:
         for ch, objs in self.channels.items():
             state = ch in self.active_channels
             for obj in set(objs):
-                if hasattr(obj, "set_channel_active"):
-                    obj.set_channel_active(state)
-                elif hasattr(obj, "active"):
-                    obj.active = state
+                obj.set_channel_active(state)
         self.active_channels.clear()
 
     def create_hook_arm(

--- a/channel.py
+++ b/channel.py
@@ -1,0 +1,16 @@
+"""Protocol for objects controlled via integer channels."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ChannelControlled(Protocol):
+    """Object that reacts to channel activation signals."""
+
+    channel: int | None
+
+    def set_channel_active(self, state: bool) -> None:
+        """Apply channel-driven activation *state*."""
+        ...

--- a/tests/test_sensor_channel.py
+++ b/tests/test_sensor_channel.py
@@ -1,10 +1,14 @@
 import os
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
 import pygame
+import math
 from builder_app import BuilderApp
 from particle import Particle
 from sensor_particle import SensorParticle
 from variable_particle import VariableParticle
+from variable_spring import VariableSpring
+from variable_bending_spring import VariableBendingSpring
+from channel import ChannelControlled
 
 
 def test_sensor_channel_toggles_variable():
@@ -34,4 +38,34 @@ def test_channelled_variable_respects_key():
     assert vp.active is True
     app._apply_channel_signals()
     assert vp.active is True
+    pygame.quit()
+
+
+def test_channel_signals_update_all_types():
+    app = BuilderApp()
+    p1 = Particle((0, 0))
+    p2 = Particle((10, 0))
+    p3 = Particle((20, 0))
+    vp = VariableParticle((0, 0), channel=1)
+    vs = VariableSpring(p1, p2, 10, 20, 10, channel=1)
+    vb = VariableBendingSpring(p1, p2, p3, math.pi / 2, math.pi / 3, 10, channel=1)
+    app.particles.extend([p1, p2, p3, vp])
+    app.variable_particles.append(vp)
+    app.variable_springs.append(vs)
+    app.variable_bending_springs.append(vb)
+    app.register_variable_particle(vp)
+    app.register_variable_spring(vs)
+    app.register_variable_bend(vb)
+    assert isinstance(vp, ChannelControlled)
+    assert isinstance(vs, ChannelControlled)
+    assert isinstance(vb, ChannelControlled)
+    app._signal_channel(1)
+    app._apply_channel_signals()
+    assert vp.active is True
+    assert vs.active is True
+    assert vb.active is True
+    app._apply_channel_signals()
+    assert vp.active is False
+    assert vs.active is False
+    assert vb.active is False
     pygame.quit()

--- a/variable_bending_spring.py
+++ b/variable_bending_spring.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import math
 
 from bending_spring import BendingSpring
+from channel import ChannelControlled
 
 
-class VariableBendingSpring(BendingSpring):
+class VariableBendingSpring(BendingSpring, ChannelControlled):
     """A bending spring that can smoothly switch between two angles.
 
     The bend behaves like a regular :class:`~bending_spring.BendingSpring` but

--- a/variable_particle.py
+++ b/variable_particle.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from particle import Particle
+from channel import ChannelControlled
 
 
-class VariableParticle(Particle):
+class VariableParticle(Particle, ChannelControlled):
     """A particle that can smoothly switch between two drag values.
 
     The particle behaves like a standard :class:`~particle.Particle` but

--- a/variable_spring.py
+++ b/variable_spring.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import pygame
 from spring import Spring
+from channel import ChannelControlled
 
 
-class VariableSpring(Spring):
+class VariableSpring(Spring, ChannelControlled):
     """A spring that can smoothly switch between two rest lengths.
 
     The spring behaves like a regular :class:`~spring.Spring` but tracks a


### PR DESCRIPTION
## Summary
- Introduce `ChannelControlled` protocol for channel-driven objects
- Have variable particle, spring and bend implement the protocol
- Simplify builder's channel signalling to operate on protocol instances
- Document and test channel protocol usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a766dcd1c08325aece8457db736890