### PR TITLE
Initialize variable particle activation flags on conversion

### DIFF
--- a/builder_ui/tools/inspect_tool.py
+++ b/builder_ui/tools/inspect_tool.py
@@ -421,7 +421,16 @@ class InspectTool(Tool):
             if old in self.app.variable_particles:
                 self.app.variable_particles.remove(old)
             try:
-                del old.base_drag, old.alt_drag, old.change_speed, old.key, old.mode, old.active
+                del (
+                    old.base_drag,
+                    old.alt_drag,
+                    old.change_speed,
+                    old.key,
+                    old.mode,
+                    old.key_active,
+                    old.channel_active,
+                    old.active,
+                )
             except AttributeError:
                 pass
             old.__class__ = Particle
@@ -434,6 +443,8 @@ class InspectTool(Tool):
             p.change_speed = cfg.speed
             p.key = cfg.key
             p.mode = cfg.mode
+            p.key_active = False
+            p.channel_active = False
             p.active = False
             p.channel = cfg.channel
             self.app.variable_particles.append(p)

--- a/tests/test_variable_particle_conversion.py
+++ b/tests/test_variable_particle_conversion.py
@@ -1,0 +1,25 @@
+import os
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+import pygame
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from builder_app import BuilderApp
+from particle import Particle
+from variable_particle import VariableParticle
+
+
+def test_convert_particle_sets_activation_flags() -> None:
+    app = BuilderApp()
+    p = Particle((0, 0))
+    app.particles.append(p)
+    tool = app.ui.inspect_tool
+    tool.particle = p
+    tool._convert_particle()
+    assert isinstance(p, VariableParticle)
+    assert hasattr(p, "key_active")
+    assert hasattr(p, "channel_active")
+    p.set_channel_active(True)
+    assert p.active
+    pygame.quit()


### PR DESCRIPTION
## Summary
- ensure conversion of normal particle to variable initializes key and channel activation flags and cleans them up on revert
- add regression test covering particle conversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a76abff05483259043f7761872f30d